### PR TITLE
Fixed duplicate registering of hooks

### DIFF
--- a/kge/job/train.py
+++ b/kge/job/train.py
@@ -524,8 +524,6 @@ class TrainingJobNegativeSampling(TrainingJob):
         )
         self.num_examples = self.dataset.train.size(0)
 
-        # let the model add some hooks, if it wants to do so
-        self.model.prepare_job(self)
         self.is_prepared = True
 
     def _get_collate_fun(self):

--- a/kge/model/inverse_relations_model.py
+++ b/kge/model/inverse_relations_model.py
@@ -40,7 +40,6 @@ class InverseRelationsModel(KgeModel):
         self._relation_embedder = self._base_model.get_p_embedder()
 
     def prepare_job(self, job, **kwargs):
-        super().prepare_job(job, **kwargs)
         self._base_model.prepare_job(job, **kwargs)
 
     def penalty(self, **kwargs):


### PR DESCRIPTION
I maybe found two small pieces of behavior that are not wanted and I propose a fix. In both cases, KgeModel.prepare_job() is called twice leading to the hooks from the model being registered twice. Case 1 can be replicated by running some negative_sampling job and Case 2 can be replicated by running a conve model.
In both cases, the post_epoch_trace_hooks list contains "append_num_param()" twice.