### PR TITLE
(WiP) Added global hooks

### DIFF
--- a/kge/job/auto_search.py
+++ b/kge/job/auto_search.py
@@ -2,7 +2,7 @@ import concurrent.futures
 from typing import List
 import torch
 from kge import Config
-from kge.job import SearchJob
+from kge.job import SearchJob, Job
 import kge.job.search
 
 # TODO handle "max_epochs" in some sensible way
@@ -23,6 +23,10 @@ class AutoSearchJob(SearchJob):
         self.trial_ids: List = []  #: backend-specific identifiers for each trial
         self.parameters: List[dict] = []  #: hyper-parameters of each trial
         self.results: List[dict] = []  #: trace entry of best result of each trial
+
+        if self.__class__ == AutoSearchJob:
+            for f in Job.job_created_hooks:
+                f(self)
 
     def load(self, filename):
         self.config.log("Loading checkpoint from {}...".format(filename))

--- a/kge/job/ax_search.py
+++ b/kge/job/ax_search.py
@@ -4,7 +4,7 @@ from ax import Models
 from ax.core import ObservationFeatures
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
 
-from kge.job import AutoSearchJob
+from kge.job import AutoSearchJob, Job
 from kge import Config
 from ax.service.ax_client import AxClient
 from typing import List
@@ -18,6 +18,10 @@ class AxSearchJob(AutoSearchJob):
         self.num_trials = self.config.get("ax_search.num_trials")
         self.num_sobol_trials = self.config.get("ax_search.num_sobol_trials")
         self.ax_client = None
+
+        if self.__class__ == AxSearchJob:
+            for f in Job.job_created_hooks:
+                f(self)
 
     # Overridden such that instances of search job can be pickled to workers
     def __getstate__(self):

--- a/kge/job/entity_pair_ranking.py
+++ b/kge/job/entity_pair_ranking.py
@@ -1,4 +1,4 @@
-from kge.job import EvaluationJob
+from kge.job import EvaluationJob, Job
 
 
 class EntityPairRankingJob(EvaluationJob):
@@ -6,3 +6,7 @@ class EntityPairRankingJob(EvaluationJob):
 
     def __init__(self, config, dataset, parent_job, model):
         super().__init__(config, dataset, parent_job, model)
+
+        if self.__class__ == EntityPairRankingJob:
+            for f in Job.job_created_hooks:
+                f(self)

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -3,7 +3,7 @@ import time
 
 import torch
 import kge.job
-from kge.job import EvaluationJob
+from kge.job import EvaluationJob, Job
 
 
 class EntityRankingJob(EvaluationJob):
@@ -12,6 +12,10 @@ class EntityRankingJob(EvaluationJob):
     def __init__(self, config, dataset, parent_job, model):
         super().__init__(config, dataset, parent_job, model)
         self.is_prepared = False
+
+        if self.__class__ == EntityRankingJob:
+            for f in Job.job_created_hooks:
+                f(self)
 
     def _prepare(self):
         """Construct all indexes needed to run."""

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -60,6 +60,10 @@ class EvaluationJob(Job):
         if config.get("eval.metric_per_argument_frequency_perc"):
             self.hist_hooks.append(FrequencyPercEvaluationHistogramHooks(self.dataset))
 
+        if self.__class__ == EvaluationJob:
+            for f in Job.job_created_hooks:
+                f(self)
+
     @staticmethod
     def create(config, dataset, parent_job=None, model=None):
         """Factory method to create an evaluation job """

--- a/kge/job/grid_search.py
+++ b/kge/job/grid_search.py
@@ -15,6 +15,10 @@ class GridSearchJob(Job):
     def __init__(self, config, dataset, parent_job=None):
         super().__init__(config, dataset, parent_job)
 
+        if self.__class__ == GridSearchJob:
+            for f in Job.job_created_hooks:
+                f(self)
+
     def run(self):
         # read grid search options range
         all_keys = []

--- a/kge/job/job.py
+++ b/kge/job/job.py
@@ -7,6 +7,11 @@ import socket
 
 
 class Job:
+
+    # static hooks for all Jobs
+    # signature: job
+    job_created_hooks = []
+
     def __init__(self, config: Config, dataset: Dataset, parent_job=None):
         self.config = config
         self.dataset = dataset
@@ -25,6 +30,10 @@ class Job:
         # prepend log entries with the job id. Since we use random job IDs but
         # want short log entries, we only output the first 8 bytes here
         self.config.log_prefix = "[" + self.job_id[0:8] + "] "
+
+        if self.__class__ == Job:
+            for f in Job.job_created_hooks:
+                f(self)
 
     def resume(self):
         """Restores all relevant state to resume a previous job.

--- a/kge/job/manual_search.py
+++ b/kge/job/manual_search.py
@@ -1,6 +1,6 @@
 import copy
 from kge import Config, Dataset
-from kge.job import SearchJob
+from kge.job import SearchJob,Job
 import kge.job.search
 import concurrent.futures
 
@@ -27,6 +27,10 @@ class ManualSearchJob(SearchJob):
 
     def __init__(self, config: Config, dataset: Dataset, parent_job=None):
         super().__init__(config, dataset, parent_job)
+
+        if self.__class__ == ManualSearchJob:
+            for f in Job.job_created_hooks:
+                f(self)
 
     def resume(self):
         # no need to do anything here; run code automatically resumes

--- a/kge/job/search.py
+++ b/kge/job/search.py
@@ -9,7 +9,6 @@ class SearchJob(Job):
 
     Provides functionality for scheduling training jobs across workers.
     """
-
     def __init__(self, config, dataset, parent_job=None):
         super().__init__(config, dataset, parent_job)
 
@@ -32,6 +31,10 @@ class SearchJob(Job):
             )
         else:
             self.process_pool = None  # marks that we run in single process
+
+        if self.__class__ == SearchJob:
+            for f in Job.job_created_hooks:
+                f(self)
 
     def create(config, dataset, parent_job=None):
         """Factory method to create a search job."""

--- a/kge/job/train.py
+++ b/kge/job/train.py
@@ -26,7 +26,6 @@ class TrainingJob(Job):
     `_compute_batch_loss`.
 
     """
-
     def __init__(self, config, dataset, parent_job=None):
         from kge.job import EvaluationJob
 
@@ -81,7 +80,11 @@ class TrainingJob(Job):
         #: Hooks run after training
         #: Signature: job, trace_entry
         self.post_train_hooks = []
-        
+
+        if self.__class__ == TrainingJob:
+            for f in Job.job_created_hooks:
+                f(self)
+
     @staticmethod
     def create(config, dataset, parent_job=None):
         """Factory method to create a training job and add necessary label_coords to
@@ -478,6 +481,10 @@ class TrainingJob1toN(TrainingJob):
 
         config.log("Initializing 1-to-N training job...")
 
+        if self.__class__ == TrainingJob1toN:
+            for f in Job.job_created_hooks:
+                f(self)
+
     def _prepare(self):
         self.type_str = "1toN"
 
@@ -640,6 +647,10 @@ class TrainingJobNegativeSampling(TrainingJob1toN):
                 self._num_negatives_o = 0
         config.log("Sampling from 1-to-N ...")
 
+        if self.__class__ == TrainingJobNegativeSampling:
+            for f in Job.job_created_hooks:
+                f(self)
+
     def _compute_batch_loss(self, batch_index, batch):
 
         # prepare
@@ -778,6 +789,10 @@ class TrainingJobNegativeSamplingLegacy(TrainingJob):
             "Initializing negative sampling training job with "
             "'{}' scoring function ...".format(self._score_func_type)
         )
+
+        if self.__class__ == TrainingJobNegativeSamplingLegacy:
+            for f in Job.job_created_hooks:
+                f(self)
 
     def _prepare(self):
         """Construct dataloader"""
@@ -981,6 +996,10 @@ class TrainingJobSpo(TrainingJob):
         super().__init__(config, dataset, parent_job)
         self.is_prepared = False
         config.log("Initializing spo training job...")
+
+        if self.__class__ == TrainingJobSpo:
+            for f in Job.job_created_hooks:
+                f(self)
 
     def _prepare(self):
         """Construct dataloader"""


### PR DESCRIPTION
This is the new pull request (PR) as mentioned in the tensorboard PR comments.
The first commit adds the static hooks, the second commit is the 'additional hook stuff' I used when I built the visualizations.
The third commit then is just a short example, how I plan to integrate the visualization codebase into the framework and only call it from kge.py. The rest of the third commit is only the visdom stuff merged in one file renamed to "visualization". Nothing else instead of the init function has changed and the older feedback is still pending, e.g. no feedback needed. I will clean up the history and remove this commit from this pull branch after the first and second commit have been reviewed and discussed.

For the static hooks, (first commit) I need feedback, this is my motivation:
I add the "job_created_hooks" to the Job, Training/Eval/ and Search-Job classes. The reason is that with that we can have hooks on Job level that will be run on any instantiation of any job. But we can also have hooks that are only run by the instantiation of a training/search/eval -job by e. g. appending with TrainingJob.job_created_hooks.append(funcOnlyForTrain). This hook then is only run for training jobs on instantiation but not for siblings. This would be different if we only would have one static Job.job_created_hooks.

There is no interference and calls do not appear in duplicate fashion, the reason is that assigning e.g. TrainingJob.job_created_hooks = [] overwrites the namespace var "job_created_hooks" which was inherited by Job. Therefore we can do:
Job.job_created_hooks.append(func1)
TrainingJob.job_created_hooks.append(func2)

Then all Jobs call func1 on instantiation and additionally TrainingJobs call also func2 on instantiation. I assume that every job calls super(), which is the case for the code I saw.

 






