### PR TITLE
Uninformative error when running a searchjob with valid.every>train.max_epochs

### DIFF
--- a/kge/job/search.py
+++ b/kge/job/search.py
@@ -32,6 +32,8 @@ class SearchJob(Job):
         else:
             self.process_pool = None  # marks that we run in single process
 
+        self.config.check_range("valid.every", 1, config.get("train.max_epochs"))
+
         if self.__class__ == SearchJob:
             for f in Job.job_created_hooks:
                 f(self)


### PR DESCRIPTION
When running some search job (e. g. toy-complex-ax.yaml) with valid.every > train.max.epochs (e. g. --valid.every=11) this raises

`Traceback (most recent call last):
 File "/home/patrick/Desktop/kge/kge.py", line 234, in <module>
    job.run()
  File "/home/patrick/Desktop/kge/kge/job/auto_search.py", line 170, in run
    (self, trial_no, config, self.num_trials, list(parameters.keys())),
  File "/home/patrick/Desktop/kge/kge/job/search.py", line 72, in submit_task
    self.ready_task_results.append(task(task_arg, device=self.free_devices[0]))
  File "/home/patrick/Desktop/kge/kge/job/search.py", line 179, in _run_train_job
    best["job"],
TypeError: 'NoneType' object does not support item deletion`

The error is simply raised because best["job"] is still None. Obviously, this is induced by a nonsensical configuration but it could have some relevance: The user could set up a config and wants to try if it runs by simply setting max_epochs=1 without thinking about valid.every (This is what happened to me).  The error might be confusing then. Additionally, in a pure training job the same nonsensical usage does not lead to an error.

Fixing this directly in the line where the error occurs leads to more exceptions in ManualSearch/AutoSearch. That's why I thought maybe an easy config check, as I propose, is the most efficient. Obviously, I'm open for no action should be taken at all.  In case my fix idea is alright, I would want to know if it is valid in the constructor, as I do it. 

