### PR TITLE
Error when loading sd_rescal model with KgeModel.load_from_checkpoint()

### DIFF
--- a/kge/model/experimental/sd_rescal.py
+++ b/kge/model/experimental/sd_rescal.py
@@ -323,3 +323,4 @@ class SparseDiagonalRescal(KgeModel):
             ),
             configuration_key=self.configuration_key,
         )
+        config.set(rel_emb_conf_key + ".dim", 0)


### PR DESCRIPTION
This is very similar to #52 and again resuming the job is not a problem. The error is:
`Relation embedding sizes are determined automatically from sd_rescal.blocks and sd_rescal.block_size or entity_embedding.dim; do not set manually.`
The reason is that the dim key has been set and then not reset to 0 after the model was built.
My fix proposal naively just does the same as the fix for #52 did.