### PR TITLE
(Finished) Readable top k predictions per triple as trace, log and terminal output

### DIFF
--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -205,6 +205,9 @@ eval:
   num_workers: 0
   pin_memory: False
   trace_level: example            # example or batch or epoch
+  predict_output: True
+  predict_output_k: 5
+  predict_output_print: True
 
   # Metrics are always computed over the entire evaluation data. Optionally,
   # certain more specific metric can be computed in addition.

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -200,14 +200,16 @@ valid:
 eval:
   data: valid
   type: entity_ranking
-  hits_at_k_s: [1, 3, 10, 50, 100, 200, 300, 400, 500, 1000]     # ks for HITS@k
+
+  predict_output: True
+  predict_output_k: 5
+  predict_output_print: True
+  hits_at_k_s: [1, 3, 10, 50, 100, 200, 300, 400, 500, 1000]     # k for HITS@k
   batch_size: 100
   num_workers: 0
   pin_memory: False
   trace_level: example            # example or batch or epoch
-  predict_output: True
-  predict_output_k: 5
-  predict_output_print: True
+
 
   # Metrics are always computed over the entire evaluation data. Optionally,
   # certain more specific metric can be computed in addition.

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -201,7 +201,7 @@ valid:
 eval:
   data: valid
   type: entity_ranking
-  hits_at_k_s: [1, 3, 10, 50, 100, 200, 300, 400, 500, 1000]     # k for HITS@k
+  hits_at_k_s: [1, 3, 10, 50, 100, 200, 300, 400, 500, 1000]     # ks for HITS@k
   batch_size: 100
   num_workers: 0
   pin_memory: False

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -38,6 +38,7 @@ dataset:
   # - 1...: arbitrary metadata fields
   entity_map: entity_map.del
   relation_map: relation_map.del
+  entity_map_realnames: entity_map_realnames.txt
 
 
 ## MODEL #######################################################################
@@ -200,16 +201,15 @@ valid:
 eval:
   data: valid
   type: entity_ranking
-
-  predict_output: True
-  predict_output_k: 5
-  predict_output_print: True
   hits_at_k_s: [1, 3, 10, 50, 100, 200, 300, 400, 500, 1000]     # k for HITS@k
   batch_size: 100
   num_workers: 0
   pin_memory: False
   trace_level: example            # example or batch or epoch
-
+  top_k_predictions:	# Possibility to inspect the predictions a model makes
+    predict: False    	# If true, the best predictions are added to the log file  
+    k: 5		# No. of best predictions retrieved
+    print: False	# If true, the predictions are outputted to the terminal
 
   # Metrics are always computed over the entire evaluation data. Optionally,
   # certain more specific metric can be computed in addition.

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -206,10 +206,10 @@ eval:
   num_workers: 0
   pin_memory: False
   trace_level: example            # example or batch or epoch
-  top_k_predictions:	# Possibility to inspect the predictions a model makes
-    predict: False    	# If true, the best predictions are added to the log file  
-    k: 5		# No. of best predictions retrieved
-    print: False	# If true, the predictions are outputted to the terminal
+  top_k_predictions:              # Possibility to inspect the predictions a model makes
+    predict: False                # If true, the best predictions are added to the log file  
+    k: 5                          # No. of best predictions retrieved
+    print: False                  # If true, the predictions are outputted to the terminal
 
   # Metrics are always computed over the entire evaluation data. Optionally,
   # certain more specific metric can be computed in addition.

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -38,7 +38,7 @@ dataset:
   # - 1...: arbitrary metadata fields
   entity_map: entity_map.del
   relation_map: relation_map.del
-  entity_map_realnames: entity_map_realnames.txt
+  entity_map_real_names: entity_map_real_names.txt
 
 
 ## MODEL #######################################################################

--- a/kge/dataset.py
+++ b/kge/dataset.py
@@ -56,10 +56,13 @@ class Dataset:
         num_relations, relations = Dataset._load_map(
             os.path.join(base_dir, config.get("dataset.relation_map"))
         )
-
-        entities_map = Dataset._load_map(
-            os.path.join(base_dir, config.get("dataset.entity_map_realnames")), "realnames"
-        )
+        try:
+            entities_map = Dataset._load_map(
+                os.path.join(base_dir, config.get("dataset.entity_map_realnames")), "realnames"
+            )
+        except FileNotFoundError:
+            config.log("No mapping from entity string ID's to real names available")
+            entities_map = "Not available"
 
         train, train_meta = Dataset._load_triples(
             os.path.join(base_dir, config.get("dataset.train"))

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -331,12 +331,11 @@ class EntityRankingJob(EvaluationJob):
             predictions = output.create_output_best_predictions(self, best_predictions_per_triple, entities_map)
             trace_entry["best_predictions_per_triple"] = predictions
 
-            # Log and trace the best predictions if desired
-            if self.predict_output_log:
-                self.config.log("{} best predictions for the test triples:".format(self.predict_output_k) + "\n" + "\n")
-                for t, p in zip(predictions.keys(), predictions.values()):
-                   self.config.log("For triple " + t + ", the {} best predictions are: ".format(self.predict_output_k) + "\n" + str(
-                            p[0]) + "\n" + str(p[1]) + "\n" + str(p[2]) + "\n" + str(p[3]) + "\n" + str(p[4]) + "\n" + "\n")
+            # Log the best predictions and print if specified in self.predict_output_log
+            self.config.log("{} best predictions for the test triples:".format(self.predict_output_k) + "\n" + "\n", echo=self.predict_output_print)
+            for t, p in zip(predictions.keys(), predictions.values()):
+               self.config.log("For triple " + t + ", the {} best predictions are: ".format(self.predict_output_k) + "\n" + str(
+                        p[0]) + "\n" + str(p[1]) + "\n" + str(p[2]) + "\n" + str(p[3]) + "\n" + str(p[4]) + "\n" + "\n", echo=self.predict_output_print)
 
             # create a file for the predictions
             f = open('{}/predictions_epoch_{}.txt'.format(self.config.folder, self.epoch), 'w')

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -5,6 +5,7 @@ import torch
 import kge.job
 from kge.job import EvaluationJob, Job
 
+
 class EntityRankingJob(EvaluationJob):
     """ Entity ranking evaluation protocol """
 

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -4,8 +4,6 @@ import time
 import torch
 import kge.job
 from kge.job import EvaluationJob, Job
-from kge.job.eval import output_predictions_per_triple as output
-
 
 class EntityRankingJob(EvaluationJob):
     """ Entity ranking evaluation protocol """
@@ -278,19 +276,6 @@ class EntityRankingJob(EvaluationJob):
                     )
                 )
         epoch_time += time.time()
-
-        # Find and report best k predictions per triple
-        if self.top_k_predictions_predict:
-            top_k_predictions = output.get_top_k_predictions(self, self.triples, self.top_k_predictions_k)
-
-            # Save the the best predictions to the log file and output them if specified
-            self.config.log("Print the {} best predictions for the {} triples:".format(self.top_k_predictions_k, self.eval_data) + "\n" + "\n",
-                            echo=self.top_k_predictions_print)
-            for t, p in zip(top_k_predictions.keys(), top_k_predictions.values()):
-                self.config.log(
-                    "For triple " + t + ", the {} best predictions are: ".format(self.top_k_predictions_k) + "\n" + str(
-                        p[0]) + "\n" + str(p[1]) + "\n" + str(p[2]) + "\n" + str(p[3]) + "\n" + str(p[4]) + "\n" + "\n",
-                    echo=self.top_k_predictions_print)
 
         # compute trace
         trace_entry = dict(

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -309,8 +309,21 @@ class EntityRankingJob(EvaluationJob):
             self.model.train()
         self.config.log("Finished evaluating on " + self.eval_data + " data.")
 
+
         for f in self.post_valid_hooks:
             f(self, trace_entry)
+
+        # Predict output
+        from kge.job.eval import output_predictions_per_triple as output
+        if self.predict_output:
+            s_all, p_all, o_all = self.triples[:, 0], self.triples[:, 1], self.triples[:, 2]
+            scores_all = self.model.score_sp_po(s_all, p_all, o_all)
+
+            best_predictions_per_triple = output.get_best_predictions_per_triple(self, self.triples, scores_all, self.predict_output_k)
+
+            entities_map = output._load_map("/home/andrej/GIT/kge/data/toy/entities_names.txt")
+
+            output.output_best_predictions(self, best_predictions_per_triple, entities_map)
 
         return trace_entry
 

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -26,7 +26,7 @@ class EvaluationJob(Job):
         self.epoch = -1
         self.predict_output = config.get("eval.predict_output")
         self.predict_output_k = config.get("eval.predict_output_k")
-        self.predict_output_log = config.get("eval.predict_output_log")
+        self.predict_output_print = config.get("eval.predict_output_print")
 
         #: Hooks run after evaluation for an epoch.
         #: Signature: job, trace_entry

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -212,10 +212,10 @@ def get_top_k_predictions(self, trace_entry):
         top_k_predictions[self.triples[t]] = best_triples
 
     if entities_map != "Not available":
-        top_k_predictions_realnames = {}
+        top_k_predictions_real_names = {}
         for i, j in zip(top_k_predictions.keys(), top_k_predictions.values()):
             try:
-                top_k_predictions_realnames[str(entities_map[''.join(entities[int(i[0])])]) +
+                top_k_predictions_real_names[str(entities_map[''.join(entities[int(i[0])])]) +
                             str(relations[int(i[1])]) +
                             str(entities_map[''.join(entities[int(i[2])])])] = \
                     ["Best prediction no. {}: ".format(n+1) +
@@ -225,7 +225,7 @@ def get_top_k_predictions(self, trace_entry):
             # Often there is no complete mapping to real names where every entity is listed. Therefore,
             # we need to output the IDs in those cases. Whenever an ID key is not present in the mapping, we use the ID.
             except KeyError:
-                top_k_predictions_realnames[str(entities_map[''.join(entities[int(i[0])])]) +
+                top_k_predictions_real_names[str(entities_map[''.join(entities[int(i[0])])]) +
                             str(relations[int(i[1])]) +
                             str(entities_map[''.join(entities[int(i[2])])])] = \
                     ["Best prediction no. {}: ".format(n+1) +
@@ -234,12 +234,12 @@ def get_top_k_predictions(self, trace_entry):
                     ''.join(entities[int(t[2])]) for n,t in enumerate(j)]
 
         # Add to trace
-        trace_entry["Top_{}_predictions_per_triple".format(self.top_k_predictions_k)] = top_k_predictions_realnames
+        trace_entry["Top_{}_predictions_per_triple".format(self.top_k_predictions_k)] = top_k_predictions_real_names
 
         # Save the the best predictions to the log file and output them if specified
         self.config.log("Best {} predictions for the {} triples:".format(self.top_k_predictions_k, self.eval_data) + "\n" + "\n",
                         echo=self.top_k_predictions_print)
-        for t, p in zip(top_k_predictions_realnames.keys(), top_k_predictions_realnames.values()):
+        for t, p in zip(top_k_predictions_real_names.keys(), top_k_predictions_real_names.values()):
             self.config.log(
                 "For triple " + t + ", the {} best predictions are: ".format(self.top_k_predictions_k) + "\n" + str(
                     p[0]) + "\n" + str(p[1]) + "\n" + str(p[2]) + "\n" + str(p[3]) + "\n" + str(p[4]) + "\n" + "\n",

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -177,49 +177,6 @@ def hist_per_frequency_percentile(hists, s, p, o, s_ranks, o_ranks, job, **kwarg
                 hists["{}_{}".format("relation", perc)][r] += 1
 
 
-    def __init__(self, dataset):
-        super().__init__(dataset)
-        self.frequency_perc = (
-            self.dataset.get_frequency_percentiles_for_entites_and_relations()
-        )
-
-    def init_hist_hook(self, device, dtype):
-        result = dict()
-        for arg in self.frequency_perc.keys():
-            for perc in self.frequency_perc[arg].keys():
-                result["{}_{}".format(arg, perc)] = torch.zeros(
-                    [self.dataset.num_entities], device=device, dtype=dtype
-                )
-        return result
-
-    def make_batch_hist(
-        self, hist_dict, s, p, o, s_ranks, o_ranks, device, dtype=torch.float
-    ):
-        for perc in self.frequency_perc[
-            "subject"
-        ].keys():  # same for relation and object
-            for r, m_s, m_r in zip(
-                s_ranks,
-                [id in self.frequency_perc["subject"][perc] for id in s.tolist()],
-                [id in self.frequency_perc["relation"][perc] for id in p.tolist()],
-            ):
-                if m_s:
-                    hist_dict["{}_{}".format("subject", perc)][r] += 1
-                if m_r:
-                    hist_dict["{}_{}".format("relation", perc)][r] += 1
-            for r, m_o, m_r in zip(
-                o_ranks,
-                [id in self.frequency_perc["object"][perc] for id in o.tolist()],
-                [id in self.frequency_perc["relation"][perc] for id in p.tolist()],
-            ):
-                if m_o:
-                    hist_dict["{}_{}".format("object", perc)][r] += 1
-                if m_r:
-                    hist_dict["{}_{}".format("relation", perc)][r] += 1
-
-        return hist_dict
-
-
 class output_predictions_per_triple():
     # Todo: Need a complete and unique-valued, english-only mapping, atm output is in different languages and unreadable
 


### PR DESCRIPTION
This contribution makes it possible to manually inspect the predictions a model makes for test triples. For every test triple, the k predictions with the highest scores are added to the trace and if possible added in an interpretable readable form to the log file and outputted.


User guidelines for the configurations:
- For the predictions to be readable, a file "entity_map_realnames.txt" has to be added to the data folder. If such a file does not exist, only the entity indices are reported. The file should contain a mapping from metadata string IDs to real entity names. 
E.g.:  "/m/027rn	"Dominican Republic"@e
For the beginning one file for freebase mappings is added to the toy data folder. To use this contribution for real data, mappings to real entity names for all datasets have to be found (preferably english only and as complete as possible).

- If eval.top_k_predictions.predict is set to True, the best k predictions are added to the trace. If a mapping to real world entity names is available, the predictions are also added to the log file with the real entity and prediction names.

- eval.top_k_predictions.k specifies the no. of predictions to be inspected

- If eval.top_k_predictions.print is set to True, the real name predictions are outputted to the terminal. This specification is added, because for large datasets, we can have a lot of triples to make predictions for. This is also the reason why by default everything is set to False.


Details considering the implementation:
- A dictionary called entities_map containing the required mapping is added to the dataset object. For loading it, a new function was created, which is very similar to the already existing _load_map function. The already existing function converts the key of the map to an integer, which cannot be done for the real names mapping (string). Changing the function would lead to a less readable function and would also change the function for the already existing mappings, so a new function was created for keeping this separated. 

- If a mapping is not present or named wrong, this is printed to the terminal and the dictionary in the dataset object is set to "Not available". In this case the trace and log file only contain the entity indices.

- The main part of contribution is the function get_top_k_predictions in eval.py, which can be used as a post_epoch_trace_hook by every evaluation type (entity_ranking, triple_classification, etc.). The function consists of the following main parts:

1. The scores for all test triples are retrieved. This is also done in the entity_ranking script, which means that the operation is executed twice in an evaluation task. To maintain the flexibility to use the function for other evaluation types which may use differently retrieved scores (e.g. triple_classification), the decision was to better do this again in the function.

2. Find the best predictions for every test triple. We create a dictionary, containing entries as {test triple: [1st predicted triple,  ..., kth predicted triple]}. Here we only operate with the entity indices.

3. The entries of this dictionary are added to the trace. Usually, it would be better to also add the real names to the trace if possible, but they often contain special characters, so that while writing out the trace, the strings get corrupted, which leads to an unreadable output. At the moment I don't see a way to fix this.

4. If a mapping to real entity names is available, the entity indexes as well as the relation indexes are replaced with the real names (stored in a new dictionary). If an entity name is not present in the real names mapping, the string metadata key is used instead. This new dictionary with the interpretable triple predictions is added to the log file in a readable way. If specified, it is also printed in the terminal.


As has been said, this contribution becomes more useful if there are good mappings to entity names. Thanks in advance for any kind of feedback!
