### PR TITLE
Faster negative sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ print(model.dataset.entity_ids(object_ids))
 For other score functions (score_sp, score_po, score_so, score_spo) see [KgeModel](kge/model/kge_model.py#L455).
 
 ## Known issues
-- Filtering of positive samples when training with `train.type=negative_sampling` can be slow. We are currently working on a more efficient implementation.
 
 ## Other KGE frameworks and KGE implementations
 

--- a/examples/toy-complex-train-sampling.yaml
+++ b/examples/toy-complex-train-sampling.yaml
@@ -22,4 +22,4 @@ negative_sampling:
     s: True
     o: True
     p: True
-    implementation: fast
+    implementation: fast_if_available

--- a/examples/toy-complex-train-sampling.yaml
+++ b/examples/toy-complex-train-sampling.yaml
@@ -1,7 +1,7 @@
 job.type: train
-dataset.name: fb15k
+dataset.name: toy
 model: complex
-
+train.num_workers: 4
 train:
   type: negative_sampling
   optimizer: Adagrad
@@ -22,7 +22,7 @@ negative_sampling:
     s: True
     o: True
     p: True
-    implementation: python
+    implementation: fast
 
 
 

--- a/examples/toy-complex-train-sampling.yaml
+++ b/examples/toy-complex-train-sampling.yaml
@@ -1,7 +1,7 @@
 job.type: train
 dataset.name: toy
 model: complex
-train.num_workers: 4
+
 train:
   type: negative_sampling
   optimizer: Adagrad
@@ -23,6 +23,3 @@ negative_sampling:
     o: True
     p: True
     implementation: fast
-
-
-

--- a/examples/toy-complex-train-sampling.yaml
+++ b/examples/toy-complex-train-sampling.yaml
@@ -1,5 +1,5 @@
 job.type: train
-dataset.name: toy
+dataset.name: fb15k
 model: complex
 
 train:
@@ -22,3 +22,6 @@ negative_sampling:
     s: True
     o: True
     p: True
+
+
+

--- a/examples/toy-complex-train-sampling.yaml
+++ b/examples/toy-complex-train-sampling.yaml
@@ -22,6 +22,7 @@ negative_sampling:
     s: True
     o: True
     p: True
+    implementation: python
 
 
 

--- a/examples/toy-complex-train-sampling.yaml
+++ b/examples/toy-complex-train-sampling.yaml
@@ -22,4 +22,4 @@ negative_sampling:
     s: True
     o: True
     p: True
-    implementation: fast
+    implementation: standard

--- a/examples/toy-complex-train-sampling.yaml
+++ b/examples/toy-complex-train-sampling.yaml
@@ -22,4 +22,4 @@ negative_sampling:
     s: True
     o: True
     p: True
-    implementation: standard
+    implementation: fast

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -192,7 +192,7 @@ negative_sampling:
     s: False       # filter s samples until all are true negatives
     p: False       # see above
     o: False       # see above
-    implementation: numba # numba; python
+    implementation: fast # standard; fast
 
   # Whether to share the s/p/o corruptions for all triples in the batch. This
   # can make training more efficient. Cannot be used with together with

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -189,7 +189,7 @@ negative_sampling:
   # Whether to resample corrupted triples that occur in the training data (and
   # are hence positives). Can be set separately for each slot.
   filtering:
-    s: False       # filter negative candidate triples created by sampling slot s
+    s: False       # filter and resample for slot s
     p: False       # as above
     o: False       # as above
 

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -193,9 +193,11 @@ negative_sampling:
     p: False       # as above
     o: False       # as above
 
-    # Set to standard or fast. Standard is a generic method which can be slow. Set only
-    # to standard if fast is not implemented for a sampler.
-    implementation: fast # standard; fast
+    # Implementation to use for filtering.
+    # standard: use slow generic implementation, available for all samplers
+    # fast: use specialized fast implementation, available for some samplers
+    # fast_if_available: use fast implementation if available, else standard
+    implementation: fast_if_available
 
   # Whether to share the s/p/o corruptions for all triples in the batch. This
   # can make training more efficient. Cannot be used with together with

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -189,9 +189,12 @@ negative_sampling:
   # Whether to resample corrupted triples that occur in the training data (and
   # are hence positives). Can be set separately for each slot.
   filtering:
-    s: False       # filter s samples until all are true negatives
-    p: False       # see above
-    o: False       # see above
+    s: False       # filter negative candidate triples created by sampling slot s
+    p: False       # as above
+    o: False       # as above
+
+    # Set to standard or fast. Standard is a generic method which can be slow. Set only
+    # to standard if fast is not implemented for a sampler.
     implementation: fast # standard; fast
 
   # Whether to share the s/p/o corruptions for all triples in the batch. This

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -189,9 +189,10 @@ negative_sampling:
   # Whether to resample corrupted triples that occur in the training data (and
   # are hence positives). Can be set separately for each slot.
   filtering:
-    s: False
-    p: False
-    o: False
+    s: False       # filter s samples until all are true negatives
+    p: False       # see above
+    o: False       # see above
+    implementation: numba # numba; python
 
   # Whether to share the s/p/o corruptions for all triples in the batch. This
   # can make training more efficient. Cannot be used with together with

--- a/kge/indexing.py
+++ b/kge/indexing.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 def _group_by(keys, values) -> dict:
-    """ Groups values by keys.
+    """Group values by keys.
 
     :param keys: list of keys
     :param values: list of values
@@ -240,7 +240,7 @@ def create_default_index_functions(dataset: "Dataset"):
 
 @njit
 def index_where_in(x, y, t_f=True):
-    """Retrieves the indices of the elements in x which are also in y.
+    """Retrieve the indices of the elements in x which are also in y.
 
     x and y are assumed to be 1 dimensional arrays.
 

--- a/kge/indexing.py
+++ b/kge/indexing.py
@@ -1,6 +1,6 @@
 import torch
 from collections import defaultdict, OrderedDict
-from numba import njit
+import numba
 import numpy as np
 
 
@@ -238,8 +238,9 @@ def create_default_index_functions(dataset: "Dataset"):
         dataset, "relation"
     )
 
-@njit
-def index_where_in(x, y, t_f=True):
+
+@numba.njit
+def where_in(x, y, t_f=True):
     """Retrieve the indices of the elements in x which are also in y.
 
     x and y are assumed to be 1 dimensional arrays.

--- a/kge/indexing.py
+++ b/kge/indexing.py
@@ -249,8 +249,7 @@ def index_where_in(x, y, t_f=True):
 
     """
     # np.isin is not supported in numba. Also: "i in y" raises an error in numba
-    # when y is a np.array. Casting y to a set instead a list was surprisingly slower.
     # Setting njit(parallel=True) slows down the function
-    list_y = list(y)
+    list_y = set(y)
     return np.where(np.array([i in list_y for i in x]) == t_f)[0]
 

--- a/kge/indexing.py
+++ b/kge/indexing.py
@@ -231,13 +231,6 @@ def create_default_index_functions(dataset: "Dataset"):
             _invert_ids, obj=obj
         )
 
-    dataset.index_functions["entity_id_to_index"] = lambda dataset: _invert_ids(
-        dataset, "entity"
-    )
-    dataset.index_functions["relation_id_to_index"] = lambda dataset: _invert_ids(
-        dataset, "relation"
-    )
-
 
 @numba.njit
 def where_in(x, y, t_f=True):
@@ -253,4 +246,3 @@ def where_in(x, y, t_f=True):
     # Setting njit(parallel=True) slows down the function
     list_y = set(y)
     return np.where(np.array([i in list_y for i in x]) == t_f)[0]
-

--- a/kge/indexing.py
+++ b/kge/indexing.py
@@ -233,16 +233,16 @@ def create_default_index_functions(dataset: "Dataset"):
 
 
 @numba.njit
-def where_in(x, y, t_f=True):
+def where_in(x, y, not_in=False):
     """Retrieve the indices of the elements in x which are also in y.
 
     x and y are assumed to be 1 dimensional arrays.
 
-    :params: t_f: if False, returns the indices of the of the elements in x
+    :params: not_in: if True, returns the indices of the of the elements in x
     which are not in y.
 
     """
     # np.isin is not supported in numba. Also: "i in y" raises an error in numba
-    # Setting njit(parallel=True) slows down the function
+    # setting njit(parallel=True) slows down the function
     list_y = set(y)
-    return np.where(np.array([i in list_y for i in x]) == t_f)[0]
+    return np.where(np.array([i in list_y for i in x]) != not_in)[0]

--- a/kge/util/sampler.py
+++ b/kge/util/sampler.py
@@ -125,8 +125,9 @@ class KgeSampler(Configurable):
         cols = [[P, O], [S, O], [S, P]][slot]
         pairs = positive_triples[:, cols]
         for i in range(positive_triples.size(0)):
-            pair = pairs[i][0].item(), pairs[i][1].item()
-            false_negatives = index.get(pair).numpy()
+            false_negatives = index.get(
+                (pairs[i][0].item(), pairs[i][1].item())
+            ).numpy()
             # indices of samples that have to be sampled again
             resample_idx = where_in(negative_samples[i].numpy(), false_negatives, True)
             # number of new samples needed
@@ -224,7 +225,7 @@ class KgeUniformSampler(KgeSampler):
                     ctr = 0
                     # numba does not support advanced indexing but the loop
                     # is optimized so it's faster than numpy anyway
-                    for j in resample_idx[num_found: num_found + len(idx)]:
+                    for j in resample_idx[num_found : num_found + len(idx)]:
                         negative_samples[i, j] = new_samples[ctr]
                         ctr += 1
                     num_found += len(idx)

--- a/kge/util/sampler.py
+++ b/kge/util/sampler.py
@@ -126,13 +126,9 @@ class KgeSampler(Configurable):
         pairs = positive_triples[:, cols]
         for i in range(positive_triples.size(0)):
             pair = pairs[i][0].item(), pairs[i][1].item()
-            false_negatives = index.get(pair)
+            false_negatives = index.get(pair).numpy()
             # indices of samples that have to be sampled again
-            # Note: giving np.isin() a set as second argument potentially is faster
-            # but conversion to a set induces costs that make things worse
-            resample_idx = np.where(
-                np.isin(negative_samples[i], false_negatives) != 0
-            )[0]
+            resample_idx = where_in(negative_samples[i].numpy(), false_negatives, True)
             # number of new samples needed
             num_new = len(resample_idx)
             # number already found of the new samples needed
@@ -143,9 +139,7 @@ class KgeSampler(Configurable):
                     positive_triples[i, None], slot, num_remaining
                 ).view(-1)
                 # indices of the true negatives
-                tn_idx = np.where(
-                    np.isin(new_samples, false_negatives) == 0
-                )[0]
+                tn_idx = where_in(new_samples.numpy(), false_negatives, False)
                 # write the true negatives found
                 if len(tn_idx):
                     negative_samples[

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(
         "sqlalchemy",
         "torchviz",
         "dataclasses",
-        "numba==0.47.0"
+        # LibKGE uses numba typed-dicts which is part of the experimental numba API
+        # in version 0.48
+        # see http://numba.pydata.org/numba-doc/0.48.0/reference/pysupported.html
+        "numba==0.48.0"
     ],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         "ax-platform>=0.1.6",
         "sqlalchemy",
         "torchviz",
-        "dataclasses"
+        "dataclasses",
+        "numba"
     ],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "sqlalchemy",
         "torchviz",
         "dataclasses",
-        "numba"
+        "numba==0.47.0"
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Reviews from the original PR have been addressed.

Approximate timings (as from the orig. PR)

30 samples; avg.  seconds per epoch; fb15k

filter type|1 worker|4 workers
-|-|-
no filter|16|14
fast|22|19
standard|42|19

60 samples; avg.  seconds per epoch; fb15k

filter type|1 worker|4 workers
-|-|-
no filter|19|20
fast|25|22
standard|47|21

120 samples; avg.  seconds per epoch; fb15k

filter type|1 worker|4 workers
-|-|-
no filter|29|29
fast|33|31.5
standard|61|31