### PR TITLE
add weighted regularization to wikidata parameters in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ LibKGE supports large datasets such as Wikidata5M (4.8M entities). The result
 given below was found by automatic hyperparameter search similar to the one used
 for the smaller datasets above, but with some values fixed (training with shared
 negative sampling, embedding dimension: 128, batch size: 1024, optimizer:
-Adagrad). We ran 30 pseudo-random configurations for 20 epochs, and then reran
-the configuration that performed best on validation data for 200 epochs.
+Adagrad, regularization: weighted). We ran 30 pseudo-random configurations for 
+20 epochs, and then reran the configuration that performed best on validation 
+data for 200 epochs.
 
 |                                                             |   MRR | Hits@1 | Hits@3 | Hits@10 |                                                                                    Config file |                                                                            Pretrained model |
 |-------------------------------------------------------------|------:|-------:|-------:|--------:|-----------------------------------------------------------------------------------------------:|--------------------------------------------------------------------------------------------:|


### PR DESCRIPTION
This is probably an important information, since non-weighted does not work with a dataset of this size.