### PR TITLE
update ax parameter name for latest ax version

### DIFF
--- a/kge/job/ax_search.py
+++ b/kge/job/ax_search.py
@@ -37,15 +37,15 @@ class AxSearchJob(AutoSearchJob):
                 steps=[
                     GenerationStep(
                         model=Models.SOBOL,
-                        num_arms=self.num_sobol_trials,
-                        min_arms_observed=ceil(self.num_sobol_trials / 2),
-                        enforce_num_arms=True,
+                        num_trials=self.num_sobol_trials,
+                        min_trials_observed=ceil(self.num_sobol_trials / 2),
+                        enforce_num_trials=True,
                         model_kwargs={'seed': 0}
                     ),
                     GenerationStep(
                         model=Models.GPEI,
-                        num_arms=-1,
-                        recommended_max_parallelism=3,
+                        num_trials=-1,
+                        max_parallelism=3,
                         model_gen_kwargs={
                             "fixed_features": ObservationFeatures(
                                 parameters={

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "pandas",
         "argparse",
         "path.py",
-        "ax-platform>=0.1.6",
+        "ax-platform>=0.1.9",
         "sqlalchemy",
         "torchviz",
         "dataclasses",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "pandas",
         "argparse",
         "path.py",
-        "ax-platform>=0.1.9",
+        "ax-platform>=0.1.10",
         "sqlalchemy",
         "torchviz",
         "dataclasses",


### PR DESCRIPTION
ax changed their parameter names with the latest update. This should fix this issue: https://github.com/uma-pi1/kge/issues/90
