### PR TITLE
Change path.py requirement to path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "pyyaml",
         "pandas",
         "argparse",
-        "path.py",
+        "path",
         "ax-platform>=0.1.10",
         "sqlalchemy",
         "torchviz",


### PR DESCRIPTION
According to https://pypi.org/project/path.py/, path.py has been renamed to path. Importing path.py installs version 12.4.0, which in turn installs path version 2.2. Example:

```
$ pip show path.py
Name: path.py
Version: 12.4.0
Summary: A module wrapper for os.path
Home-page: https://github.com/jaraco/path
Author: Jason Orendorff
Author-email: jason.orendorff@gmail.com
License: UNKNOWN
Location: /x/tsafavi/kge/venv/lib/python3.7/site-packages/path.py-12.4.0-py3.7.egg
Requires: path
Required-by: libkge
```

```
$ pip show path
Name: path
Version: 2.2
Summary: A module wrapper for os.path
Home-page: http://www.jorendorff.com/articles/python/path/
Author: Jason Orendorff
Author-email: jason@jorendorff.com
License: Public domain
Location: /x/tsafavi/kge/venv/lib/python3.7/site-packages/path-2.2-py3.7.egg
Requires:
Required-by: path.py
```

In turn, path version 2.2 causes the following error when run with python 3.7:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.7/runpy.py", line 142, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.7/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/x/tsafavi/kge/kge/__init__.py", line 2, in <module>
    from kge.dataset import Dataset
  File "/x/tsafavi/kge/kge/dataset.py", line 14, in <module>
    from kge.misc import kge_base_dir
  File "/x/tsafavi/kge/kge/misc.py", line 5, in <module>
    from path import Path
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 963, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 906, in _find_spec
  File "<frozen importlib._bootstrap_external>", line 1280, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1254, in _get_spec
  File "<frozen importlib._bootstrap_external>", line 1235, in _legacy_get_spec
  File "<frozen importlib._bootstrap>", line 441, in spec_from_loader
  File "<frozen importlib._bootstrap_external>", line 594, in spec_from_file_location
  File "/x/tsafavi/kge/venv/lib/python3.7/site-packages/path-2.2-py3.7.egg/path.py", line 886
    def mkdir(self, mode=0777):
                            ^
SyntaxError: invalid token
```