### PR TITLE
Fix RT3 and projection embedder penalty

### DIFF
--- a/examples/toy-rt3-train.yaml
+++ b/examples/toy-rt3-train.yaml
@@ -6,19 +6,19 @@ relational_tucker3:
   entity_embedder:
     dim: 50
     dropout: 0.02
-    regularize: 'l2'
+    regularize: 'lp'
     regularize_args:
       weight: 4e-12
 
   relation_embedder:
     dropout: 0.3
-    regularize: 'l2'
+    regularize: 'lp'
     regularize_args:
       weight: 6e-16
     base_embedder:
       dim: 50
       dropout: 0.3
-      regularize: 'l2'
+      regularize: 'lp'
       regularize_args:
         weight: 6e-12
 

--- a/kge/model/embedder/projection_embedder.yaml
+++ b/kge/model/embedder/projection_embedder.yaml
@@ -10,7 +10,7 @@ projection_embedder:
   initialize_args:
     +++: +++
   dropout: 0.                 # dropout used for embeddings
-  normalize: ''               # alternatively: normalize '', L2
-  regularize: 'l2'              # '', 'l1', 'l2'
+  regularize: 'lp'              # '', 'lp'
+  regularize_weight: 0.0
   regularize_args:
-    weight: 0.0
+    p: 2.0


### PR DESCRIPTION
 Was broken since refactor to "lp" argument isntead of "l1", "l2", ... and further broken by refactor to have named penalties 