### PR TITLE
Fix initialize_args in projection_embedder.py

### DIFF
--- a/kge/model/embedder/projection_embedder.py
+++ b/kge/model/embedder/projection_embedder.py
@@ -25,10 +25,17 @@ class ProjectionEmbedder(KgeEmbedder):
         self.dropout = self.get_option("dropout")
         self.regularize = self.check_option("regularize", ["", "lp"])
         self.projection = torch.nn.Linear(self.base_embedder.dim, self.dim, bias=False)
+
+        init_ = self.get_option("initialize")
+        try:
+            init_args = self.get_option("initialize_args." + init_)
+        except KeyError:
+            init_args = self.get_option("initialize_args")
+            
         self.initialize(
             self.projection.weight.data,
-            self.get_option("initialize"),
-            self.get_option("initialize_args"),
+            init_,
+            init_args
         )
 
     def _embed(self, embeddings):


### PR DESCRIPTION
Update `projection_embedder.py` to check `initialize_args` underneath the `initialize` key first, following the convention in https://github.com/uma-pi1/kge/blob/faec621d76c1e66a4107b74a3aed14048a4327a4/kge/model/embedder/lookup_embedder.yaml#L19-L29

This allows the following example to be run:
```
job.type: train
dataset.name: toy
model: relational_tucker3

relational_tucker3:
  relation_embedder:
    initialize: normal_
    initialize_args:
      normal_:
        mean: 1.0
        std: 0.3
```
