### PR TITLE
Factor out embedding initialization for KgeEmbedders

### DIFF
--- a/kge/model/embedder/lookup_embedder.py
+++ b/kge/model/embedder/lookup_embedder.py
@@ -34,18 +34,7 @@ class LookupEmbedder(KgeEmbedder):
         )
 
         # initialize weights
-        init_ = self.get_option("initialize")
-        try:
-            init_args = self.get_option("initialize_args." + init_)
-        except KeyError:
-            init_args = self.get_option("initialize_args")
-
-        # Automatically set arg a (lower bound) for uniform_ if not given
-        if init_ == "uniform_" and "a" not in init_args:
-            init_args["a"] = init_args["b"] * -1
-            self.set_option("initialize_args.a", init_args["a"], log=True)
-
-        self.initialize(self._embeddings.weight.data, init_, init_args)
+        self._init_embeddings(self._embeddings.weight.data)
 
         # TODO handling negative dropout because using it with ax searches for now
         dropout = self.get_option("dropout")

--- a/kge/model/embedder/projection_embedder.py
+++ b/kge/model/embedder/projection_embedder.py
@@ -25,18 +25,7 @@ class ProjectionEmbedder(KgeEmbedder):
         self.dropout = self.get_option("dropout")
         self.regularize = self.check_option("regularize", ["", "lp"])
         self.projection = torch.nn.Linear(self.base_embedder.dim, self.dim, bias=False)
-
-        init_ = self.get_option("initialize")
-        try:
-            init_args = self.get_option("initialize_args." + init_)
-        except KeyError:
-            init_args = self.get_option("initialize_args")
-            
-        self.initialize(
-            self.projection.weight.data,
-            init_,
-            init_args
-        )
+        self._init_embeddings(self.projection.weight.data)
 
     def _embed(self, embeddings):
         embeddings = self.projection(embeddings)

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -222,18 +222,18 @@ class KgeEmbedder(KgeBase):
     def _init_embeddings(self, data: Tensor):
         """Initialize embeddings with provided configuration."""
         initialize = self.get_option("initialize")
-        initialize_args_key = "initialize_args"
 
         try:
-            initialize_args = self.get_option(
-                initialize_args_key + "." + initialize)
+            initialize_args_key = "initialize_args." + initialize
+            initialize_args = self.get_option(initialize_args_key)
         except KeyError:
+            initialize_args_key = "initialize_args"
             initialize_args = self.get_option(initialize_args_key)
 
         # Automatically set arg a (lower bound) for uniform_ if not given
         if initialize == "uniform_" and "a" not in initialize_args:
             initialize_args["a"] = initialize_args["b"] * -1
-            self.set_option(initialize_args_key, initialize_args["a"], log=True)
+            self.set_option(initialize_args_key + ".a", initialize_args["a"], log=True)
 
         self.initialize(data, initialize, initialize_args)
 

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -219,6 +219,24 @@ class KgeEmbedder(KgeBase):
 
         self.dim: int = self.get_option("dim")
 
+    def _init_embeddings(self, data: Tensor):
+        """Initialize embeddings with provided configuration."""
+        initialize = self.get_option("initialize")
+        initialize_args_key = "initialize_args"
+
+        try:
+            initialize_args = self.get_option(
+                initialize_args_key + "." + initialize)
+        except KeyError:
+            initialize_args = self.get_option(initialize_args_key)
+
+        # Automatically set arg a (lower bound) for uniform_ if not given
+        if initialize == "uniform_" and "a" not in initialize_args:
+            initialize_args["a"] = initialize_args["b"] * -1
+            self.set_option(initialize_args_key, initialize_args["a"], log=True)
+
+        self.initialize(data, initialize, initialize_args)
+
     @staticmethod
     def create(
         config: Config, dataset: Dataset, configuration_key: str, vocab_size: int


### PR DESCRIPTION
Factor out embedding initialization to `KgeEmbedder._init_embeddings`. As per @rgemulla's comment in https://github.com/uma-pi1/kge/pull/122, two subclasses of `KgeEmbedder` rely on the same logic for initialization. 