### PR TITLE
Clean up hooks.

### DIFF
--- a/kge/job/auto_search.py
+++ b/kge/job/auto_search.py
@@ -227,14 +227,17 @@ class AutoSearchJob(SearchJob):
                 )
             )
 
-            self.trace(
-                even="search_completed",
+        job_trace = dict(
+                **job_trace,
+                event="search_completed",
                 echo=True,
                 echo_prefix="  ",
                 log=True,
                 scope="search",
                 **self.results[best_trial_index]
             )
+
+        return job_trace
 
         # DISABLED FOR NOW SINCE IDENTICAL TO BEST TRIAL
         # output parameter estimates

--- a/kge/job/auto_search.py
+++ b/kge/job/auto_search.py
@@ -91,7 +91,7 @@ class AutoSearchJob(SearchJob):
 
     # -- Main --------------------------------------------------------------------------
 
-    def _run(self, job_trace : Dict[str, Any]):
+    def _run(self, job_trace : Dict[str, Any]) -> Dict[str, Any]:
 
         # let's go
         trial_no = 0

--- a/kge/job/auto_search.py
+++ b/kge/job/auto_search.py
@@ -1,5 +1,5 @@
 import concurrent.futures
-from typing import List
+from typing import List, Any, Dict
 import torch
 from kge import Config
 from kge.config import _process_deprecated_options
@@ -91,7 +91,7 @@ class AutoSearchJob(SearchJob):
 
     # -- Main --------------------------------------------------------------------------
 
-    def _run(self):
+    def _run(self, job_trace : Dict[str, Any]):
 
         # let's go
         trial_no = 0

--- a/kge/job/ax_search.py
+++ b/kge/job/ax_search.py
@@ -1,13 +1,10 @@
 from math import ceil
 
 from ax import Models
-from ax.core import ObservationFeatures
 from ax.modelbridge.generation_strategy import GenerationStep, GenerationStrategy
-
-from kge.job import AutoSearchJob, Job
-from kge import Config
 from ax.service.ax_client import AxClient
-from typing import List
+from kge import Config
+from kge.job import AutoSearchJob, Job
 
 
 class AxSearchJob(AutoSearchJob):

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -400,8 +400,6 @@ class EntityRankingJob(EvaluationJob):
             event="eval_completed",
             **metrics,
         )
-        for f in self.post_epoch_trace_hooks:
-            f(self, trace_entry)
 
         # if validation metric is not present, try to compute it
         metric_name = self.config.get("valid.metric")
@@ -419,9 +417,6 @@ class EntityRankingJob(EvaluationJob):
         if was_training:
             self.model.train()
         self.config.log("Finished evaluating on " + self.eval_split + " split.")
-
-        for f in self.post_valid_hooks:
-            f(self, trace_entry)
 
         return trace_entry
 

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -78,7 +78,7 @@ class EntityRankingJob(EvaluationJob):
         return batch, label_coords, test_label_coords
 
     @torch.no_grad()
-    def _run(self, job_trace : Dict[str, Any]):
+    def _run(self, job_trace : Dict[str, Any]) -> Dict[str, Any]:
 
         was_training = self.model.training
         self.model.eval()

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -34,25 +34,6 @@ class EvaluationJob(Job):
         self.filter_with_test = config.get("entity_ranking.filter_with_test")
         self.epoch = -1
 
-        #: Hooks run after training for an epoch.
-        #: Signature: job, trace_entry
-        self.post_epoch_hooks = []
-
-        #: Hooks run before starting a batch.
-        #: Signature: job
-        self.pre_batch_hooks = []
-
-        #: Hooks run before outputting the trace of a batch. Can modify trace entry.
-        #: Signature: job, trace_entry
-        self.post_batch_trace_hooks = []
-
-        #: Hooks run before outputting the trace of an epoch. Can modify trace entry.
-        #: Signature: job, trace_entry
-        self.post_epoch_trace_hooks = []
-
-        #: Signature: job, trace_entry
-        self.post_valid_hooks = []
-
         #: Whether to create additional histograms for head and tail slot
         self.head_and_tail = config.get("entity_ranking.metrics_per.head_and_tail")
 

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -4,7 +4,7 @@ from kge import Config, Dataset
 from kge.job import Job
 from kge.model import KgeModel
 
-from typing import Dict, Union, Optional
+from typing import Dict, Union, Optional, Any
 
 
 class EvaluationJob(Job):
@@ -65,7 +65,7 @@ class EvaluationJob(Job):
         else:
             raise ValueError("eval.type")
 
-    def _run(self) -> dict:
+    def _run(self, job_trace : Dict[str, Any]):
         """ Compute evaluation metrics, output results to trace file """
         raise NotImplementedError
 

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -65,7 +65,7 @@ class EvaluationJob(Job):
         else:
             raise ValueError("eval.type")
 
-    def _run(self, job_trace : Dict[str, Any]):
+    def _run(self, job_trace : Dict[str, Any]) -> Dict[str, Any]:
         """ Compute evaluation metrics, output results to trace file """
         raise NotImplementedError
 

--- a/kge/job/grid_search.py
+++ b/kge/job/grid_search.py
@@ -74,3 +74,5 @@ class GridSearchJob(Job):
             job.run()
         else:
             self.config.log("Skipping running of search job as requested by user...")
+
+        return job_trace

--- a/kge/job/grid_search.py
+++ b/kge/job/grid_search.py
@@ -21,7 +21,7 @@ class GridSearchJob(Job):
             for f in Job.job_created_hooks:
                 f(self)
 
-    def _run(self, job_trace : Dict[str, Any]):
+    def _run(self, job_trace : Dict[str, Any]) -> Dict[str, Any]:
         # read grid search options range
         all_keys = []
         all_keys_short = []

--- a/kge/job/grid_search.py
+++ b/kge/job/grid_search.py
@@ -1,4 +1,6 @@
 import os
+from typing import Any, Dict
+
 from kge.job import Job
 from kge import Config
 import itertools
@@ -19,7 +21,7 @@ class GridSearchJob(Job):
             for f in Job.job_created_hooks:
                 f(self)
 
-    def _run(self):
+    def _run(self, job_trace : Dict[str, Any]):
         # read grid search options range
         all_keys = []
         all_keys_short = []

--- a/kge/job/job.py
+++ b/kge/job/job.py
@@ -149,9 +149,12 @@ class Job:
         and run some post run hooks and return the result.
         :return: trace of the job.
         """
+
+        job_type = self.config.get("job.type")
+
         job_trace = {
-            "type": self.config.get("job.type"),
-            "scope": "job",
+            "type": self.config.get(f"{job_type}.type"),
+            # "scope": "job",
         }
 
         if not self._is_prepared:
@@ -165,7 +168,7 @@ class Job:
         for f in self.post_run_hooks:
             f(self, job_trace)
 
-        self.trace(**job_trace)
+        job_trace = self.trace(**job_trace)
 
         return job_trace
 

--- a/kge/job/job.py
+++ b/kge/job/job.py
@@ -172,7 +172,7 @@ class Job:
 
         return job_trace
 
-    def _run(self, job_trace : Dict[str, Any]):
+    def _run(self, job_trace : Dict[str, Any]) -> Dict[str, Any]:
         raise NotImplementedError
 
     def trace(self, **kwargs) -> Dict[str, Any]:

--- a/kge/job/manual_search.py
+++ b/kge/job/manual_search.py
@@ -1,4 +1,6 @@
 import copy
+from typing import Any, Dict
+
 from kge import Config, Dataset
 from kge.job import SearchJob, Job
 import kge.job.search
@@ -32,7 +34,7 @@ class ManualSearchJob(SearchJob):
             for f in Job.job_created_hooks:
                 f(self)
 
-    def _run(self):
+    def _run(self, job_trace : Dict[str, Any]):
         # read search configurations and expand them to full configs
         search_configs = copy.deepcopy(self.config.get("manual_search.configurations"))
         all_keys = set()

--- a/kge/job/manual_search.py
+++ b/kge/job/manual_search.py
@@ -34,7 +34,7 @@ class ManualSearchJob(SearchJob):
             for f in Job.job_created_hooks:
                 f(self)
 
-    def _run(self, job_trace : Dict[str, Any]):
+    def _run(self, job_trace : Dict[str, Any]) -> Dict[str, Any]:
         # read search configurations and expand them to full configs
         search_configs = copy.deepcopy(self.config.get("manual_search.configurations"))
         all_keys = set()

--- a/kge/job/manual_search.py
+++ b/kge/job/manual_search.py
@@ -109,11 +109,15 @@ class ManualSearchJob(SearchJob):
             prefix="  ",
         )
         self.config.log("Best overall result:")
-        self.trace(
-            event="search_completed",
-            echo=True,
-            echo_prefix="  ",
-            log=True,
-            scope="search",
-            **overall_best
-        )
+
+        job_trace = dict(
+                **job_trace,
+                event="search_completed",
+                echo=True,
+                echo_prefix="  ",
+                log=True,
+                scope="search",
+                **overall_best
+            )
+
+        return job_trace

--- a/kge/job/search.py
+++ b/kge/job/search.py
@@ -214,7 +214,7 @@ def _run_train_job(sicnk, device=None):
             best["job_id"],
             best["type"],
             best["parent_job_id"],
-            best["scope"],
+            # best["scope"],
             best["event"],
         )
         search_job.trace(

--- a/kge/job/trace.py
+++ b/kge/job/trace.py
@@ -1,17 +1,8 @@
-import yaml
-import pandas as pd
 import re
-import os
-import torch
-import sys
-import csv
-from collections import OrderedDict
 import subprocess
-import time
 
-
-from kge.misc import kge_base_dir
-from kge.config import Config
+import pandas as pd
+import yaml
 
 
 class Trace:

--- a/kge/job/train.py
+++ b/kge/job/train.py
@@ -134,7 +134,7 @@ class TrainingJob(Job):
             # perhaps TODO: try class with specified name -> extensibility
             raise ValueError("train.type")
 
-    def _run(self) -> None:
+    def _run(self, job_trace : Dict[str, Any]):
         """Start/resume the training job and run to completion."""
         self.config.log("Starting training...")
         checkpoint_every = self.config.get("train.checkpoint.every")
@@ -245,7 +245,9 @@ class TrainingJob(Job):
                                 self.config.checkpoint_file(delete_checkpoint_epoch)
                             )
                         )
-        self.trace(event="train_completed")
+
+        job_trace["event"] = "train_completed"
+        return job_trace
 
     def save(self, filename) -> None:
         """Save current state to specified file"""

--- a/kge/job/train.py
+++ b/kge/job/train.py
@@ -134,7 +134,7 @@ class TrainingJob(Job):
             # perhaps TODO: try class with specified name -> extensibility
             raise ValueError("train.type")
 
-    def _run(self, job_trace : Dict[str, Any]):
+    def _run(self, job_trace : Dict[str, Any]) -> Dict[str, Any]:
         """Start/resume the training job and run to completion."""
         self.config.log("Starting training...")
         checkpoint_every = self.config.get("train.checkpoint.every")

--- a/kge/model/embedder/lookup_embedder.py
+++ b/kge/model/embedder/lookup_embedder.py
@@ -72,8 +72,9 @@ class LookupEmbedder(KgeEmbedder):
                             )
                         )
 
+            job.pre_run_hooks.append(normalize_embeddings)
             if job.config.get("job.type") == "train":
-                job.pre_batch_hooks.append(normalize_embeddings)
+                job.post_batch_hooks.append(normalize_embeddings)
 
     @torch.no_grad()
     def init_pretrained(self, pretrained_embedder: KgeEmbedder) -> None:

--- a/kge/model/embedder/lookup_embedder.py
+++ b/kge/model/embedder/lookup_embedder.py
@@ -72,7 +72,8 @@ class LookupEmbedder(KgeEmbedder):
                             )
                         )
 
-            job.pre_batch_hooks.append(normalize_embeddings)
+            if job.config.get("job.type") == "train":
+                job.pre_batch_hooks.append(normalize_embeddings)
 
     @torch.no_grad()
     def init_pretrained(self, pretrained_embedder: KgeEmbedder) -> None:

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -580,10 +580,11 @@ class KgeModel(KgeBase):
         self._entity_embedder.prepare_job(job, **kwargs)
         self._relation_embedder.prepare_job(job, **kwargs)
 
-        def append_num_parameter(job, trace):
-            trace["num_parameters"] = sum(map(lambda p: p.numel(), self.parameters()))
+        def append_num_parameter(job):
+            self.config.log(f"num_parameters: {sum(map(lambda p: p.numel(), self.parameters()))}")
 
-        job.post_epoch_trace_hooks.append(append_num_parameter)
+        if job.config.get("job.type") == "train":
+            job.pre_train_hooks.append(append_num_parameter)
 
     def penalty(self, **kwargs) -> List[Tensor]:
         # Note: If the subject and object embedder are identical, embeddings may be

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -584,7 +584,7 @@ class KgeModel(KgeBase):
             self.config.log(f"num_parameters: {sum(map(lambda p: p.numel(), self.parameters()))}")
 
         if job.config.get("job.type") == "train":
-            job.pre_train_hooks.append(append_num_parameter)
+            job.pre_run_hooks.append(append_num_parameter)
 
     def penalty(self, **kwargs) -> List[Tensor]:
         # Note: If the subject and object embedder are identical, embeddings may be

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -580,10 +580,10 @@ class KgeModel(KgeBase):
         self._entity_embedder.prepare_job(job, **kwargs)
         self._relation_embedder.prepare_job(job, **kwargs)
 
-        def append_num_parameter(job):
-            self.config.log(f"num_parameters: {sum(map(lambda p: p.numel(), self.parameters()))}")
+        def append_num_parameter(job, trace):
+            trace["num_parameters"] = sum(map(lambda p: p.numel(), self.parameters()))
 
-        if job.config.get("job.type") == "train":
+        if job.config.get("job.type") == "eval":
             job.pre_run_hooks.append(append_num_parameter)
 
     def penalty(self, **kwargs) -> List[Tensor]:


### PR DESCRIPTION
Clean up hooks. Was triggered by adressing the reviews in https://github.com/uma-pi1/kge/pull/119 to add a pre_batch_hook.

- Removed unused hooks from eval.py and entity_ranking.py that where apparently copied there from TrainJob without any purpose, their names did not make sense and post_valid_hooks was run twice apparently.

- added pre_batch_hook and pre_train_hook

- changed signature of post_train_hook, because there is no trace_entry

- move logging of num_parameters to pre_train_hook, logging it just once, instead every epoch

- guard adding a hook by querying the job.type