### PR TITLE
Streamline preparing job across jobs; adding pre and post run hooks

### DIFF
--- a/kge/job/auto_search.py
+++ b/kge/job/auto_search.py
@@ -58,10 +58,6 @@ class AutoSearchJob(SearchJob):
 
     # -- Abstract methods --------------------------------------------------------------
 
-    def init_search(self):
-        """Initialize to start a new search experiment."""
-        raise NotImplementedError
-
     def register_trial(self, parameters=None):
         """Start a new trial.
 
@@ -95,8 +91,7 @@ class AutoSearchJob(SearchJob):
 
     # -- Main --------------------------------------------------------------------------
 
-    def run(self):
-        self.init_search()
+    def _run(self):
 
         # let's go
         trial_no = 0

--- a/kge/job/ax_search.py
+++ b/kge/job/ax_search.py
@@ -30,6 +30,7 @@ class AxSearchJob(AutoSearchJob):
         return state
 
     def _prepare(self):
+        super()._prepare()
         if self.num_sobol_trials > 0:
             # BEGIN: from /ax/service/utils/dispatch.py
             generation_strategy = GenerationStrategy(

--- a/kge/job/ax_search.py
+++ b/kge/job/ax_search.py
@@ -29,7 +29,7 @@ class AxSearchJob(AutoSearchJob):
         del state["ax_client"]
         return state
 
-    def init_search(self):
+    def _prepare(self):
         if self.num_sobol_trials > 0:
             # BEGIN: from /ax/service/utils/dispatch.py
             generation_strategy = GenerationStrategy(

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -25,6 +25,7 @@ class EntityRankingJob(EvaluationJob):
                 f(self)
 
     def _prepare(self):
+        super()._prepare()
         """Construct all indexes needed to run."""
 
         # create data and precompute indexes

--- a/kge/job/entity_ranking.py
+++ b/kge/job/entity_ranking.py
@@ -27,9 +27,6 @@ class EntityRankingJob(EvaluationJob):
     def _prepare(self):
         """Construct all indexes needed to run."""
 
-        if self.is_prepared:
-            return
-
         # create data and precompute indexes
         self.triples = self.dataset.split(self.config.get("eval.split"))
         for split in self.filter_splits:
@@ -79,8 +76,7 @@ class EntityRankingJob(EvaluationJob):
         return batch, label_coords, test_label_coords
 
     @torch.no_grad()
-    def run(self) -> dict:
-        self._prepare()
+    def _run(self) -> dict:
 
         was_training = self.model.training
         self.model.eval()

--- a/kge/job/eval.py
+++ b/kge/job/eval.py
@@ -84,7 +84,7 @@ class EvaluationJob(Job):
         else:
             raise ValueError("eval.type")
 
-    def run(self) -> dict:
+    def _run(self) -> dict:
         """ Compute evaluation metrics, output results to trace file """
         raise NotImplementedError
 

--- a/kge/job/grid_search.py
+++ b/kge/job/grid_search.py
@@ -19,7 +19,7 @@ class GridSearchJob(Job):
             for f in Job.job_created_hooks:
                 f(self)
 
-    def run(self):
+    def _run(self):
         # read grid search options range
         all_keys = []
         all_keys_short = []

--- a/kge/job/job.py
+++ b/kge/job/job.py
@@ -64,8 +64,8 @@ class Job:
         self.pre_run_hooks: List[Callable[[Job], Any]] = []
 
         #: Hooks after running a job
-        #: Signature: job
-        self.post_run_hooks: List[Callable[[Job], Any]] = []
+        #: Signature: job, dict returned by the run method
+        self.post_run_hooks: List[Callable[[Job, Dict], Any]] = []
 
 
     @staticmethod
@@ -159,7 +159,7 @@ class Job:
         result = self._run()
 
         for f in self.post_run_hooks:
-            f(self)
+            f(self, result)
 
         return result
 

--- a/kge/job/manual_search.py
+++ b/kge/job/manual_search.py
@@ -32,7 +32,7 @@ class ManualSearchJob(SearchJob):
             for f in Job.job_created_hooks:
                 f(self)
 
-    def run(self):
+    def _run(self):
         # read search configurations and expand them to full configs
         search_configs = copy.deepcopy(self.config.get("manual_search.configurations"))
         all_keys = set()

--- a/kge/job/train.py
+++ b/kge/job/train.py
@@ -469,6 +469,7 @@ class TrainingJob(Job):
         Guaranteed to be called exactly once before running the first epoch.
 
         """
+        super()._prepare()
         self.model.prepare_job(self)  # let the model add some hooks
 
     @dataclass


### PR DESCRIPTION
Was triggered by https://github.com/uma-pi1/kge/pull/124 's request to add a pre and post run hook. Turned out that there was code duplication for preparing jobs. Now every job has a pre and post run hook. And every job gets its _prepare called *once* from the Job-level.