### PR TITLE
Updated tucker3_relation_embedder.yaml

### DIFF
--- a/kge/model/embedder/tucker3_relation_embedder.yaml
+++ b/kge/model/embedder/tucker3_relation_embedder.yaml
@@ -11,6 +11,9 @@ tucker3_relation_embedder:
   initialize: normal_          # xavier, uniform, normal
   initialize_args:
     +++: +++
+  pretrain:
+    model_filename: "" 
+    ensure_all: False
   dropout: 0.                 # dropout used for mixing matrices
   normalize: ''               # alternatively: normalize '', L2
   regularize: 'l2'              # '', 'l1', 'l2'


### PR DESCRIPTION
With the new pretrained initialization options, the toy example for RT3 yields this error: `KeyError: 'Error accessing pretrain for key relational_tucker3.relation_embedder.pretrain.model_filename'`.  It looks like the relation embedder for Tucker needs the pretrained arguments in the config file as well.