### PR TITLE
Revision of hooks, fix of embedding normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### August 2020
+- PR [#138](https://github.com/uma-pi1/kge/pull/138): Revision of hooks, fix of embedding normalization
 - PR [#135](https://github.com/uma-pi1/kge/pull/135): Revised sampling API, faster negative sampling with shared samples
 
 #### June 2020

--- a/kge/config.py
+++ b/kge/config.py
@@ -677,7 +677,7 @@ def _process_deprecated_options(options: Dict[str, Any]):
             else:
                 raise ValueError(f"key {key} is deprecated and has been removed.")
 
-    # deletes a key with a regular expression
+    # deletes a key with a regular expression if it takes the given value (else error)
     def delete_key_re_with_default_value(key_regex, value):
         regex = re.compile(key_regex)
         for old_key in list(options.keys()):
@@ -685,14 +685,15 @@ def _process_deprecated_options(options: Dict[str, Any]):
                 if options[old_key] == value:
                     print(
                         f"Warning: key {old_key} is deprecated and has been removed."
-                        " Ignoring key since it has default value.",
+                        " Ignoring key since it has its value is compatible with the"
+                        " current implementation.",
                         file=sys.stderr,
                     )
                     del options[old_key]
                 else:
                     raise ValueError(
-                        f"key {old_key} with value {value} is deprecated and is not "
-                        f"supported any more."
+                        f"Warning: key {old_key} is deprecated and has been removed."
+                        f" The specified value {options[old_key]} is not supported any more."
                     )
 
     # renames a set of keys matching a regular expression
@@ -715,6 +716,9 @@ def _process_deprecated_options(options: Dict[str, Any]):
                 if rename_value(key, old_value, new_value):
                     renamed_keys.add(key)
         return renamed_keys
+
+    # 13.6.2020
+    delete_key_re_with_default_value(".*normalize.with_grad", False)
 
     # 10.6.2020
     rename_key("eval.filter_splits", "entity_ranking.filter_splits")
@@ -802,8 +806,5 @@ def _process_deprecated_options(options: Dict[str, Any]):
         "eval.metric_per_argument_frequency_perc",
         "entity_ranking.metrics_per.argument_frequency",
     )
-
-    # 13.6.2020
-    delete_key_re_with_default_value(".*normalize.with_grad", False)
 
     return options

--- a/kge/config.py
+++ b/kge/config.py
@@ -677,6 +677,17 @@ def _process_deprecated_options(options: Dict[str, Any]):
             else:
                 raise ValueError(f"key {key} is deprecated and has been removed.")
 
+    # deletes a key with a regular expression
+    def delete_key_re(key_regex):
+        regex = re.compile(key_regex)
+        for old_key in list(options.keys()):
+            if regex.match(old_key):
+                print(
+                    f"Warning: key {old_key} is deprecated and has been removed.",
+                    file=sys.stderr,
+                )
+                del options[old_key]
+
     # renames a set of keys matching a regular expression
     def rename_keys_re(key_regex, replacement):
         renamed_keys = set()
@@ -784,4 +795,8 @@ def _process_deprecated_options(options: Dict[str, Any]):
         "eval.metric_per_argument_frequency_perc",
         "entity_ranking.metrics_per.argument_frequency",
     )
+
+    # 13.6.2020
+    delete_key_re(".*normalize.with_grad")
+
     return options

--- a/kge/config.py
+++ b/kge/config.py
@@ -678,15 +678,22 @@ def _process_deprecated_options(options: Dict[str, Any]):
                 raise ValueError(f"key {key} is deprecated and has been removed.")
 
     # deletes a key with a regular expression
-    def delete_key_re(key_regex):
+    def delete_key_re_with_default_value(key_regex, value):
         regex = re.compile(key_regex)
         for old_key in list(options.keys()):
             if regex.match(old_key):
-                print(
-                    f"Warning: key {old_key} is deprecated and has been removed.",
-                    file=sys.stderr,
-                )
-                del options[old_key]
+                if options[old_key] == value:
+                    print(
+                        f"Warning: key {old_key} is deprecated and has been removed."
+                        " Ignoring key since it has default value.",
+                        file=sys.stderr,
+                    )
+                    del options[old_key]
+                else:
+                    raise ValueError(
+                        f"key {old_key} with value {value} is deprecated and is not "
+                        f"supported any more."
+                    )
 
     # renames a set of keys matching a regular expression
     def rename_keys_re(key_regex, replacement):
@@ -797,6 +804,6 @@ def _process_deprecated_options(options: Dict[str, Any]):
     )
 
     # 13.6.2020
-    delete_key_re(".*normalize.with_grad")
+    delete_key_re_with_default_value(".*normalize.with_grad", False)
 
     return options

--- a/kge/job/__init__.py
+++ b/kge/job/__init__.py
@@ -1,5 +1,6 @@
 from kge.job.trace import Trace
 from kge.job.job import Job
+from kge.job.job import TrainingOrEvaluationJob
 from kge.job.train import TrainingJob
 from kge.job.eval import EvaluationJob
 from kge.job.grid_search import GridSearchJob

--- a/kge/job/search.py
+++ b/kge/job/search.py
@@ -156,7 +156,9 @@ def _run_train_job(sicnk, device=None):
         metric_name = search_job.config.get("valid.metric")
         valid_trace = []
 
-        def copy_to_search_trace(job, trace_entry):
+        def copy_to_search_trace(job, trace_entry = None):
+            if trace_entry is None:
+                trace_entry = job.valid_trace[-1]
             trace_entry = copy.deepcopy(trace_entry)
             for key in trace_keys:
                 # Process deprecated options to some extent. Support key renames, but

--- a/kge/model/embedder/lookup_embedder.py
+++ b/kge/model/embedder/lookup_embedder.py
@@ -38,7 +38,6 @@ class LookupEmbedder(KgeEmbedder):
             self.vocab_size,
             self.dim,
             sparse=self.sparse,
-            norm_type=self.normalize_p if self.normalize_p > 0 else None,
         )
 
         if not init_for_load_only:
@@ -58,6 +57,17 @@ class LookupEmbedder(KgeEmbedder):
 
     def prepare_job(self, job: Job, **kwargs):
         super().prepare_job(job, **kwargs)
+        if self.normalize_p > 0:
+            def normalize_embeddings(job : "TrainingJob", trace_entry: Dict[str,str]=None):
+                with torch.no_grad():
+                    self._embeddings.weight.data =\
+                        torch.nn.functional.normalize(
+                            self._embeddings.weight.data, p=self.normalize_p, dim=-1
+                        )
+            # normalize before starting a batch
+            job.pre_batch_hooks.append(normalize_embeddings)
+            # normalize after an epoch (before validation and checkpoint is saved)
+            job.post_epoch_hooks.append(normalize_embeddings)
 
     @torch.no_grad()
     def init_pretrained(self, pretrained_embedder: KgeEmbedder) -> None:

--- a/kge/model/embedder/lookup_embedder.py
+++ b/kge/model/embedder/lookup_embedder.py
@@ -34,19 +34,12 @@ class LookupEmbedder(KgeEmbedder):
         if len(round_embedder_dim_to) > 0:
             self.dim = round_to_points(round_embedder_dim_to, self.dim)
 
-        # setup embedder
-        if self.normalize_p > 0:
-            self._embeddings = torch.nn.Embedding(
-                self.vocab_size,
-                self.dim,
-                sparse=self.sparse,
-                norm_type=self.normalize_p,
-                max_norm=1.0,
-            )
-        else:
-            self._embeddings = torch.nn.Embedding(
-                self.vocab_size, self.dim, sparse=self.sparse
-            )
+        self._embeddings = torch.nn.Embedding(
+            self.vocab_size,
+            self.dim,
+            sparse=self.sparse,
+            norm_type=self.normalize_p if self.normalize_p > 0 else None,
+        )
 
         if not init_for_load_only:
             # initialize weights

--- a/kge/model/embedder/lookup_embedder.yaml
+++ b/kge/model/embedder/lookup_embedder.yaml
@@ -49,9 +49,6 @@ lookup_embedder:
     # l_p norm to use. Negative numbers mean do not normalize.
     p: -1.                    # common choices: 1., 2.
 
-    # Whether to push gradients through normalization.
-    with_grad: False
-
   # Whether and how embeddings should be regularized. Possible values are '' (do
   # not regularize) or lp (defaults to p=2; else set regularize_args.p)
   regularize: 'lp'


### PR DESCRIPTION
This integrates and revises the changes from #124 and #119 into a single PR. I.e.:

1. The hook system is greatly simplified. There are now pre/post hooks for batches, epochs, and run methods.
2. The hooks are used to fix a bug in embedder normalization, which is currently not applied correctly (see #119).