### PR TITLE
Faster read of triple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### November 2020
+- PR [#155](https://github.com/uma-pi1/kge/pull/155): Faster reading of triple files
+
 #### October 2020
 - [d275419](https://github.com/uma-pi1/kge/commit/d275419bbd1e2eea6872d733fc10f30c171e9f45), [87c5463](https://github.com/uma-pi1/kge/commit/87c54630807e7ecf71ad05c042d3b1c953c44807): Support parameter groups with group-specific optimizer args
 - PR [#152](https://github.com/uma-pi1/kge/pull/152): Added training loss evaluation job

--- a/kge/dataset.py
+++ b/kge/dataset.py
@@ -173,7 +173,9 @@ class Dataset(Configurable):
             if triples is not None:
                 return triples
 
-        triples = np.loadtxt(filename, usecols=range(0, 3), dtype=np.int32)
+        # numpy loadtxt is very slow, use python read instead
+        with open(filename) as f:
+            triples = np.array([line.strip().split(delimiter)[:3] for line in f], dtype=np.int32)
         triples = torch.from_numpy(triples)
         if use_pickle:
             Dataset._pickle_dump_atomic(triples, pickle_filename)

--- a/kge/dataset.py
+++ b/kge/dataset.py
@@ -80,7 +80,11 @@ class Dataset(Configurable):
         if filename is None:
             raise IOError("Filename for key {} not specified in config".format(key))
         if not os.path.exists(os.path.join(self.folder, filename)):
-            raise IOError("File {} for key {} could not be found".format(os.path.join(self.folder, filename), key))
+            raise IOError(
+                "File {} for key {} could not be found".format(
+                    os.path.join(self.folder, filename), key
+                )
+            )
 
     @staticmethod
     def create(config: Config, preload_data: bool = True, folder: Optional[str] = None):
@@ -175,7 +179,9 @@ class Dataset(Configurable):
 
         # numpy loadtxt is very slow, use python read instead
         with open(filename) as f:
-            triples = np.array([line.strip().split(delimiter)[:3] for line in f], dtype=np.int32)
+            triples = np.array(
+                [line.strip().split(delimiter)[:3] for line in f], dtype=np.int32
+            )
         triples = torch.from_numpy(triples)
         if use_pickle:
             Dataset._pickle_dump_atomic(triples, pickle_filename)

--- a/kge/dataset.py
+++ b/kge/dataset.py
@@ -6,6 +6,7 @@ import uuid
 import torch
 from torch import Tensor
 import numpy as np
+import pandas as pd
 import pickle
 import inspect
 
@@ -177,11 +178,10 @@ class Dataset(Configurable):
             if triples is not None:
                 return triples
 
-        # numpy loadtxt is very slow, use python read instead
-        with open(filename) as f:
-            triples = np.array(
-                [line.strip().split(delimiter)[:3] for line in f], dtype=np.int32
-            )
+        # numpy loadtxt is very slow, use pandas instead
+        triples = pd.read_csv(
+            filename, sep=delimiter, dtype=np.int32, header=None, usecols=range(0, 3)
+        ).to_numpy()
         triples = torch.from_numpy(triples)
         if use_pickle:
             Dataset._pickle_dump_atomic(triples, pickle_filename)


### PR DESCRIPTION
numpy loadtxt is very slow. Using basic python operations is ~5 times faster for reading yago:

read 10x train.del  |  time
----------------    |   ---------:
old         |      31.1s
new       |      6.3s