### PR TITLE
Plugin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 #### December 2020
+- PR [#158](https://github.com/uma-pi1/kge/pull/158): Add a plugin mechanism (thanks @sfschouten)
 - PR [#157](https://github.com/uma-pi1/kge/pull/157): Add CoDEx datasets and pretrained models (thanks @tsafavi)
 
 #### November 2020

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ kge start examples/toy-complex-train.yaml --job.device cpu
 2. [Results and pretrained models](#results-and-pretrained-models)
 3. [Using LibKGE](#using-libkge)
 4. [Currently supported KGE models](#currently-supported-kge-models)
-6. [Adding a new model or embedder](#adding-a-new-model-or-embedder)
+6. [Extending LibKGE](#extending-libkge)
 6. [Known issues](#known-issues)
 7. [Changelog](CHANGELOG.md)
 8. [Other KGE frameworks](#other-kge-frameworks)
@@ -443,33 +443,26 @@ The [examples](examples) folder contains some configuration files as examples of
 
 We welcome contributions to expand the list of supported models! Please see [CONTRIBUTING](CONTRIBUTING.md) for details and feel free to initially open an issue.
 
-## Adding a new model or embedder
+## Extending LibKGE
 
-Before adding a model or embedder, you need to decide if you want to add them in a separate package or within LibKGE itself.
-Which of those two options is more suited depends on your use case. 
-Implementing it within LibKGE makes sense if you are implementing a model that you think could/should be added to this repository.
-It also makes more sense if you don't plan on publishing what you create at all, for example if you just want to play around with the code. 
-A separate package might be more appropriate if you want to develop one or more models/embedders, that for whatever reason should not be part of this repository, but that you still want to publish.
+LibKGE models implement the `KgeModel` class and generally consist of a
+`KgeEmbedder` to associate each subject, relation and object to an embedding and
+a `KgeScorer` to score triples given their embeddings. You may add new models,
+embedders, or scorers by extending the respective classes. All these base
+classes are defined in [kge_model.py](kge/model/kge_model.py).
 
-To add a new model to LibKGE, extend the
-[KgeModel](https://github.com/uma-pi1/kge/blob/1c69d8a6579d10e9d9c483994941db97e04f99b3/kge/model/kge_model.py#L243)
-class. A model is made up of a
-[KgeEmbedder](https://github.com/uma-pi1/kge/blob/1c69d8a6579d10e9d9c483994941db97e04f99b3/kge/model/kge_model.py#L170)
-to associate each subject, relation and object to an embedding, and a
-[KgeScorer](https://github.com/uma-pi1/kge/blob/1c69d8a6579d10e9d9c483994941db97e04f99b3/kge/model/kge_model.py#L76)
-to score triples given their embeddings.
+Your implementation should be stored in file `<model-name>.py` and its
+configuration options in file `<model-name>.yaml` (see [here](kge/model/)).
+You may store these files directly in the LibKGE module folders (i.e.,
+`<kge-home>/kge/model` or `<kge-home>/kge/model/embedder`) or in your own
+module. In the former case, make sure to import your code in the ``__init.py__``
+files in these folders. In the latter case, add your module to the `modules` key
+in the configuration file so that LibKGE finds it (see
+[config-default.yaml](kge/config-default.yaml)).
 
-The model implementation should be stored under
-`<kge-home>/kge/model/<model-name>.py`, its configuration options under
-`<kge-home>/kge/model/<model-name>.yaml` and its import has to be added to `<kge-home>/kge/model/__init__.py`.
-
-The embdedder implementation should be stored under
-`<kge-home>/kge/model/embedder/<embedder-name>.py`, its configuration options under
-`<kge-home>/kge/model/embedder/<embedder-name>.yaml` and its import has to be added to `<kge-home>/kge/model/__init__.py`.
-
-If you are developing in a separate package, the models/embedders can be in any python module.
-All you need to do is make sure that any module from which models and embedders must be loaded is present under the `modules` key in the config file.
-
+If you plan to contribute your code to LibKGE, we suggest to directly develop in
+the LibKGE module folders. If you just want to play around or publish your code
+separately from LibKGE, use your own module.
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ kge start examples/toy-complex-train.yaml --job.device cpu
 2. [Results and pretrained models](#results-and-pretrained-models)
 3. [Using LibKGE](#using-libkge)
 4. [Currently supported KGE models](#currently-supported-kge-models)
-5. [Adding a new model](#adding-a-new-model)
+6. [Adding a new model or embedder](#adding-a-new-model-or-embedder)
 6. [Known issues](#known-issues)
 7. [Changelog](CHANGELOG.md)
 8. [Other KGE frameworks](#other-kge-frameworks)
@@ -445,6 +445,12 @@ We welcome contributions to expand the list of supported models! Please see [CON
 
 ## Adding a new model or embedder
 
+Before adding a model or embedder, you need to decide if you want to add them in a separate package or within LibKGE itself.
+Which of those two options is more suited depends on your use case. 
+Implementing it within LibKGE makes sense if you are implementing a model that you think could/should be added to this repository.
+It also makes more sense if you don't plan on publishing what you create at all, for example if you just want to play around with the code. 
+A separate package might be more appropriate if you want to develop one or more models/embedders, that for whatever reason should not be part of this repository, but that you still want to publish.
+
 To add a new model to LibKGE, extend the
 [KgeModel](https://github.com/uma-pi1/kge/blob/1c69d8a6579d10e9d9c483994941db97e04f99b3/kge/model/kge_model.py#L243)
 class. A model is made up of a
@@ -460,6 +466,10 @@ The model implementation should be stored under
 The embdedder implementation should be stored under
 `<kge-home>/kge/model/embedder/<embedder-name>.py`, its configuration options under
 `<kge-home>/kge/model/embedder/<embedder-name>.yaml` and its import has to be added to `<kge-home>/kge/model/__init__.py`.
+
+If you are developing in a separate package, the models/embedders can be in any python module.
+All you need to do is make sure that any module from which models and embedders must be loaded is present under the `modules` key in the config file.
+
 
 ## Known issues
 

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -1,3 +1,4 @@
+
 # config-default.yaml: LibKGE's default configuration options
 
 # Control output is printed to the console.
@@ -122,6 +123,14 @@ dataset:
 
   # Additional dataset specific keys can be added as needed
   +++: +++
+
+## MODULES #####################################################################
+
+# Python modules that should be searched when loading models, embedders, etc.
+# The modules are searched in order, if there are multiple components with the 
+# same name the first match is used.
+modules: [ kge.model, kge.model.embedder ]
+
 
 ## MODEL #######################################################################
 

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -1,4 +1,3 @@
-
 # config-default.yaml: LibKGE's default configuration options
 
 # Control output is printed to the console.
@@ -124,11 +123,12 @@ dataset:
   # Additional dataset specific keys can be added as needed
   +++: +++
 
+
 ## MODULES #####################################################################
 
-# Python modules that should be searched when loading models, embedders, etc.
-# The modules are searched in order, if there are multiple components with the 
-# same name the first match is used.
+# Python modules that should be searched for models, embedders, etc. LibKGE may
+# not respect the module order specified here, so make sure to use unique
+# model/embedder names.
 modules: [ kge.model, kge.model.embedder ]
 
 

--- a/kge/config.py
+++ b/kge/config.py
@@ -12,6 +12,7 @@ from enum import Enum
 import yaml
 from typing import Any, List, Dict, Optional, Union
 
+
 class Config:
     """Configuration options.
 
@@ -31,9 +32,9 @@ class Config:
             self.options = {}
 
         self.folder = folder  # main folder (config file, checkpoints, ...)
-        self.log_folder: Optional[str] = (
-            None  # None means use self.folder; used for kge.log, trace.yaml
-        )
+        self.log_folder: Optional[
+            str
+        ] = None  # None means use self.folder; used for kge.log, trace.yaml
         self.log_prefix: str = None
 
     # -- ACCESS METHODS ----------------------------------------------------------------
@@ -251,8 +252,9 @@ class Config:
         module_config.set("modules", module_names, create=True)
 
         from kge.misc import filename_in_module
-        filename = filename_in_module(self.modules(), f"{module_name}.yaml")
-        module_config.load(filename, create=True)
+
+        config_filename = filename_in_module(self.modules(), f"{module_name}.yaml")
+        module_config.load(config_filename, create=True)
 
         if "import" in module_config.options:
             del module_config.options["import"]
@@ -326,6 +328,7 @@ class Config:
             modules = modules.union(new_options.get("modules"))
             self.set("modules", list(modules), create=True)
             del new_options["modules"]
+
         # import model configurations
         if "model" in new_options:
             model = new_options.get("model")
@@ -333,6 +336,8 @@ class Config:
             # search with model as a search parameter
             if model:
                 self._import(model)
+
+        # import explicit imports
         if "import" in new_options:
             imports = new_options.get("import")
             if not isinstance(imports, list):
@@ -578,6 +583,7 @@ class Config:
 
     def modules(self) -> List[types.ModuleType]:
         import importlib
+
         return [importlib.import_module(m) for m in self.get("modules")]
 
 

--- a/kge/misc.py
+++ b/kge/misc.py
@@ -29,7 +29,7 @@ def init_from(class_name: str, module_names: List[str], *args, **kwargs):
         if hasattr(module, class_name):
             return getattr(module, class_name)(*args, **kwargs)
     else:
-        raise ValueError(f"Can't find class {class_name} in modules: {module_names}")
+        raise ValueError(f"Can't find class {class_name} in modules {module_names}")
 
 def is_number(s, number_type):
     """ Returns True is string is a number. """

--- a/kge/misc.py
+++ b/kge/misc.py
@@ -6,6 +6,31 @@ from path import Path
 import inspect
 import subprocess
 
+import importlib
+
+def init_from(class_name: str, module_names: List[str], *args, **kwargs):
+    """Initializes class from its name and list of module names it might be part of.
+
+    Args:
+        class_name: the name of the class that is to be initialized.
+        module_names: the list of module names that are to be searched for the class.
+        *args: the non-keyword arguments for the constructor of the given class.
+        **kwargs: the keyword arguments for the constructor of the given class.
+
+    Returns:
+        An instantiation of the class that first matched the given name during the
+        search through the given modules.
+
+    Raises:
+        ValueError: If the given class cannot be found in any of the given modules.
+    """
+    modules = [importlib.import_module(m) for m in module_names]
+    for module in modules:
+        if hasattr(module, class_name):
+            return getattr(module, class_name)(*args, **kwargs)
+    else:
+        raise ValueError(f"Can't find class {class_name} in modules: {module_names}")
+
 def is_number(s, number_type):
     """ Returns True is string is a number. """
     try:
@@ -13,7 +38,6 @@ def is_number(s, number_type):
         return True
     except ValueError:
         return False
-
 
 # from https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script
 def get_git_revision_hash():
@@ -67,10 +91,12 @@ def which(program):
     return None
 
 
-def kge_base_dir():
-    import kge
-    return os.path.abspath(filename_in_module(kge, ".."))
+def module_base_dir(module_name):
+    module = importlib.import_module(module_name)
+    return os.path.abspath(filename_in_module(module, ".."))
 
+def kge_base_dir():
+    return module_base_dir("kge")
 
 def filename_in_module(module_or_module_list, filename):
     if not isinstance(module_or_module_list, list):

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -76,10 +76,11 @@ class KgeBase(torch.nn.Module, Configurable):
         # Automatically set arg a (lower bound) for uniform_ if not given
         if initialize == "uniform_" and "a" not in initialize_args:
             initialize_args["a"] = initialize_args["b"] * -1
-            config.set_option(initialize_args_key + ".a", initialize_args["a"], log=True)
+            config.set_option(
+                initialize_args_key + ".a", initialize_args["a"], log=True
+            )
 
         KgeBase._initialize(what, initialize, initialize_args)
-
 
     def prepare_job(self, job: "Job", **kwargs):
         r"""Prepares the given job to work with this model.
@@ -256,7 +257,6 @@ class KgeEmbedder(KgeBase):
 
         self.dim: int = self.get_option("dim")
 
-
     @staticmethod
     def create(
         config: Config,
@@ -283,9 +283,9 @@ class KgeEmbedder(KgeBase):
                 vocab_size,
                 init_for_load_only=init_for_load_only,
             )
-            return embedder 
+            return embedder
         except:
-            config.log(f"Failed to create embedder {embedder_type}.")
+            config.log(f"Failed to create embedder {embedder_type} (class {class_name}).")
             raise
 
     def _intersect_ids_with_pretrained_embedder(
@@ -489,7 +489,7 @@ class KgeModel(KgeBase):
 
         try:
             model = init_from(
-                class_name, 
+                class_name,
                 config.get("modules"),
                 config=config,
                 dataset=dataset,
@@ -499,7 +499,7 @@ class KgeModel(KgeBase):
             model.to(config.get("job.device"))
             return model
         except:
-            config.log(f"Failed to create model {model_name}.")
+            config.log(f"Failed to create model {model_name} (class {class_name}).")
             raise
 
     @staticmethod
@@ -590,7 +590,9 @@ class KgeModel(KgeBase):
         self._relation_embedder.prepare_job(job, **kwargs)
 
         from kge.job import TrainingOrEvaluationJob
+
         if isinstance(job, TrainingOrEvaluationJob):
+
             def append_num_parameter(job):
                 job.current_trace["epoch"]["num_parameters"] = sum(
                     map(lambda p: p.numel(), job.model.parameters())
@@ -615,7 +617,8 @@ class KgeModel(KgeBase):
                         (triples[:, S].view(-1, 1), triples[:, O].view(-1, 1)), dim=1
                     )
                 entity_penalty_result = self.get_s_embedder().penalty(
-                    indexes=entity_indexes, **kwargs,
+                    indexes=entity_indexes,
+                    **kwargs,
                 )
                 if not weighted:
                     # backwards compatibility


### PR DESCRIPTION
Hi!

I've been working on support for plugins. I thought it would make sense for LibKGE to allow Models, Embedders and Datasets to be loaded from packages other than LibKGE itself. This would be especially useful if people want to implement KGE methods using LibKGE that are, for example, not relevant enough for official support within this repository to make sense.

I've implemented it by adding a 'plugins' field to the config, in which a list of packages can be specified. These packages are then included in the search for the correct configs/classes whenever an embedder/model/dataset is loaded.

Please let me know if this feature, and my way of implementing it makes sense to you.

Thanks, Stefan