### PR TITLE
remove the obsolete TODO comments

### DIFF
--- a/kge/job/eval_entity_ranking.py
+++ b/kge/job/eval_entity_ranking.py
@@ -156,7 +156,7 @@ class EntityRankingJob(EvaluationJob):
 
             # construct a sparse label tensor of shape batch_size x 2*num_entities
             # entries are either 0 (false) or infinity (true)
-            # TODO add timing information
+
             batch = batch_coords[0].to(self.device)
             s, p, o = batch[:, 0], batch[:, 1], batch[:, 2]
             label_coords = batch_coords[1].to(self.device)


### PR DESCRIPTION
##### SUMMARY
Remove the obsolete TODO comments. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
kge/kge/job/eval_entity_ranking.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The pending task of the TODO comment has already performed in the earlier version, but the TODO comment was not removed accordingly at the moment. Please check the following commit (https://github.com/uma-pi1/kge/commit/2fa6ba193212f79e461843ba008885d648078d97).