### PR TITLE
fix loading of pretrained reciprocal relations model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-#### Februar 2021
+#### March 2021
+- PR [#191](https://github.com/uma-pi1/kge/pull/191): Fix loading of pretrained embeddings with reciprocal relation models
+
+#### February 2021
 - [27e8a32](https://github.com/uma-pi1/kge/commit/27e8a323d208106d7b75f4e003ea4b73c1c5d58d): improve validation time by allowing bulk KvsAll index lookup and improved history computation
 - PR [#154](https://github.com/uma-pi1/kge/pull/154): store checkpoint containing the initialized model for reproducibility
 - [9e88117](https://github.com/uma-pi1/kge/commit/9e88117b3bf3f91b1c22f17d88eae2f77b5e3d3e): Add Transformer model and learning rate warmup (thanks nluedema)

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -254,7 +254,6 @@ class KgeEmbedder(KgeBase):
 
         self.dim: int = self.get_option("dim")
 
-
     @staticmethod
     def create(
         config: Config,
@@ -283,7 +282,9 @@ class KgeEmbedder(KgeBase):
             )
             return embedder
         except:
-            config.log(f"Failed to create embedder {embedder_type} (class {class_name}).")
+            config.log(
+                f"Failed to create embedder {embedder_type} (class {class_name})."
+            )
             raise
 
     def _intersect_ids_with_pretrained_embedder(
@@ -316,6 +317,32 @@ class KgeEmbedder(KgeBase):
         _, self_intersect_ind, pretrained_intersect_ind = np.intersect1d(
             self_ids, pretrained_ids, return_indices=True
         )
+        if (
+            "reciprocal_relations_model" in self.config.get("model")
+            and "relation_embedder" in self.configuration_key
+        ):
+            if "reciprocal_relations_model" not in pretrained_embedder.config.get(
+                "model"
+            ):
+                raise ValueError(
+                    "Can only initialize a reciprocal relations model "
+                    "with another reciprocal relations model"
+                )
+            # add indexes for reciprocal relations
+            # during creation of a reciprocal model num_relations is already doubled
+            self_intersect_ind = np.concatenate(
+                (
+                    self_intersect_ind,
+                    self_intersect_ind + int(self.dataset.num_relations() / 2),
+                )
+            )
+            pretrained_intersect_ind = np.concatenate(
+                (
+                    pretrained_intersect_ind,
+                    pretrained_intersect_ind
+                    + int(pretrained_embedder.dataset.num_relations() / 2),
+                )
+            )
         if self.get_option("pretrain.ensure_all") and not len(
             self_intersect_ind
         ) == len(self_ids):
@@ -616,8 +643,7 @@ class KgeModel(KgeBase):
                         (triples[:, S].view(-1, 1), triples[:, O].view(-1, 1)), dim=1
                     )
                 entity_penalty_result = self.get_s_embedder().penalty(
-                    indexes=entity_indexes,
-                    **kwargs,
+                    indexes=entity_indexes, **kwargs,
                 )
                 if not weighted:
                     # backwards compatibility

--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -317,32 +317,6 @@ class KgeEmbedder(KgeBase):
         _, self_intersect_ind, pretrained_intersect_ind = np.intersect1d(
             self_ids, pretrained_ids, return_indices=True
         )
-        if (
-            "reciprocal_relations_model" in self.config.get("model")
-            and "relation_embedder" in self.configuration_key
-        ):
-            if "reciprocal_relations_model" not in pretrained_embedder.config.get(
-                "model"
-            ):
-                raise ValueError(
-                    "Can only initialize a reciprocal relations model "
-                    "with another reciprocal relations model"
-                )
-            # add indexes for reciprocal relations
-            # during creation of a reciprocal model num_relations is already doubled
-            self_intersect_ind = np.concatenate(
-                (
-                    self_intersect_ind,
-                    self_intersect_ind + int(self.dataset.num_relations() / 2),
-                )
-            )
-            pretrained_intersect_ind = np.concatenate(
-                (
-                    pretrained_intersect_ind,
-                    pretrained_intersect_ind
-                    + int(pretrained_embedder.dataset.num_relations() / 2),
-                )
-            )
         if self.get_option("pretrain.ensure_all") and not len(
             self_intersect_ind
         ) == len(self_ids):

--- a/kge/model/reciprocal_relations_model.py
+++ b/kge/model/reciprocal_relations_model.py
@@ -26,6 +26,11 @@ class ReciprocalRelationsModel(KgeModel):
         # Using a dataset with twice the number of relations to initialize base model
         alt_dataset = dataset.shallow_copy()
         alt_dataset._num_relations = dataset.num_relations() * 2
+        reciprocal_relation_ids = [
+            rel_id + "_reciprocal" for rel_id in alt_dataset.relation_ids()
+        ]
+        alt_dataset._meta["relation_ids"].extend(reciprocal_relation_ids)
+        alt_dataset.relation_ids()
         base_model = KgeModel.create(
             config=config,
             dataset=alt_dataset,

--- a/kge/model/reciprocal_relations_model.py
+++ b/kge/model/reciprocal_relations_model.py
@@ -30,7 +30,6 @@ class ReciprocalRelationsModel(KgeModel):
             rel_id + "_reciprocal" for rel_id in alt_dataset.relation_ids()
         ]
         alt_dataset._meta["relation_ids"].extend(reciprocal_relation_ids)
-        alt_dataset.relation_ids()
         base_model = KgeModel.create(
             config=config,
             dataset=alt_dataset,


### PR DESCRIPTION
fix for #190 

can not override the method _intersect_ids_with_pretrained_embedder in reciprocal_relations_model.py since the base model is created before the reciprocal relations model