### PR TITLE
convert key to correct type (np.int32) in kvsall index

### DIFF
--- a/kge/util/sampler.py
+++ b/kge/util/sampler.py
@@ -706,7 +706,7 @@ class KgeUniformSampler(KgeSampler):
             f"{self.filtering_split}_{pair_str}_to_{SLOT_STR[slot]}"
         )
         cols = [[P, O], [S, O], [S, P]][slot]
-        pairs = positive_triples[:, cols].numpy()
+        pairs = positive_triples[:, cols].numpy().astype(np.int32)
         batch_size = positive_triples.size(0)
         voc_size = self.vocabulary_size[slot]
         # filling a numba-dict here and then call the function was faster than 1. Using


### PR DESCRIPTION
ensure that the key in the kvsAll index always has the correct type.
fixes lookup in fast-filtering in negative sampling.