### PR TITLE
Use torch.isclose to determine ties

### DIFF
--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -492,6 +492,10 @@ entity_ranking:
   # mean_reciprocal_rank_filtered_with_test.
   filter_with_test: True
 
+  # Tie detection tolerances i.e. how close should scores be to count them as ties, see torch.isclose for more details.
+  tie_detection_atol: 1e-08
+  tie_detection_rtol: 1e-05
+
   # How to handle cases with ties between the correct answer and other answers, e.g.,
   #  Query: (s, p, ?).
   #  Answers and score: a:10, b:10, c:10, d:11, e:9

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -492,26 +492,28 @@ entity_ranking:
   # mean_reciprocal_rank_filtered_with_test.
   filter_with_test: True
 
-  # Tie detection tolerances i.e. how close should scores be to count them as ties, see torch.isclose for more details.
-  tie_detection_atol: 1e-08
-  tie_detection_rtol: 1e-05
+  tie_handling:
 
-  # How to handle cases with ties between the correct answer and other answers, e.g.,
-  #  Query: (s, p, ?).
-  #  Answers and score: a:10, b:10, c:10, d:11, e:9
-  #  Correct: 'a'.
-  #
-  # Possible options are:
-  # - worst_rank:        Use the highest rank of all answers that have the same
-  #                      score as the correct answer. In example: 4.
-  # - best_rank:         Use the lowest rank of all answers that have the same
-  #                      score as the correct answer (competition scoring). In
-  #                      example: 2.
-  #                      DO NOT USE THIS OPTION, it leads to misleading evaluation
-  #                      results. See https://arxiv.org/pdf/1911.03903.pdf
-  # - rounded_mean_rank: Average between worst and best rank, rounded up
-  #                      (rounded fractional ranking). In example: 3.
-  tie_handling: rounded_mean_rank
+    # How to handle cases with ties between the correct answer and other answers, e.g.,
+    #  Query: (s, p, ?).
+    #  Answers and score: a:10, b:10, c:10, d:11, e:9
+    #  Correct: 'a'.
+    #
+    # Possible options are:
+    # - worst_rank:        Use the highest rank of all answers that have the same
+    #                      score as the correct answer. In example: 4.
+    # - best_rank:         Use the lowest rank of all answers that have the same
+    #                      score as the correct answer (competition scoring). In
+    #                      example: 2.
+    #                      DO NOT USE THIS OPTION, it leads to misleading evaluation
+    #                      results. See https://arxiv.org/pdf/1911.03903.pdf
+    # - rounded_mean_rank: Average between worst and best rank, rounded up
+    #                      (rounded fractional ranking). In example: 3.
+    type: rounded_mean_rank
+
+    # Tie detection tolerances i.e. how close should scores be to count them as ties, see torch.isclose for more details.
+    atol: 1e-08
+    rtol: 1e-05
 
   # Compute Hits@K for these choices of K
   hits_at_k_s: [1, 3, 10, 50, 100, 200, 300, 400, 500, 1000]

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -512,8 +512,8 @@ entity_ranking:
     type: rounded_mean_rank
 
     # Tie detection tolerances i.e. how close should scores be to count them as ties, see torch.isclose for more details.
-    atol: 1e-08
-    rtol: 1e-05
+    atol: 1e-05
+    rtol: 1e-04
 
   # Compute Hits@K for these choices of K
   hits_at_k_s: [1, 3, 10, 50, 100, 200, 300, 400, 500, 1000]

--- a/kge/config-default.yaml
+++ b/kge/config-default.yaml
@@ -511,7 +511,8 @@ entity_ranking:
     #                      (rounded fractional ranking). In example: 3.
     type: rounded_mean_rank
 
-    # Tie detection tolerances i.e. how close should scores be to count them as ties, see torch.isclose for more details.
+    # Tie detection tolerances. These two values determine when scores are close enough to be counted as ties;
+    # see torch.isclose for details.
     atol: 1e-05
     rtol: 1e-04
 

--- a/kge/config.py
+++ b/kge/config.py
@@ -746,6 +746,9 @@ def _process_deprecated_options(options: Dict[str, Any]):
                     renamed_keys.add(key)
         return renamed_keys
 
+    # 08.09.21
+    rename_key("entity_ranking.tie_handling", "entity_ranking.tie_handling.type")
+
     # 15.12.20
     rename_value("search.type", "ax", "ax_search")
     rename_value("search.type", "manual", "manual_search")

--- a/kge/job/eval_entity_ranking.py
+++ b/kge/job/eval_entity_ranking.py
@@ -14,13 +14,13 @@ class EntityRankingJob(EvaluationJob):
     def __init__(self, config: Config, dataset: Dataset, parent_job, model):
         super().__init__(config, dataset, parent_job, model)
         self.config.check(
-            "entity_ranking.tie_handling",
+            "entity_ranking.tie_handling.type",
             ["rounded_mean_rank", "best_rank", "worst_rank"],
         )
+        self.tie_handling = self.config.get("entity_ranking.tie_handling.type")
 
-        self.tie_atol = float(self.config.get("entity_ranking.tie_detection_atol"))
-        self.tie_rtol = float(self.config.get("entity_ranking.tie_detection_rtol"))
-        self.tie_handling = self.config.get("entity_ranking.tie_handling")
+        self.tie_atol = float(self.config.get("entity_ranking.tie_handling.atol"))
+        self.tie_rtol = float(self.config.get("entity_ranking.tie_handling.rtol"))
 
         self.filter_with_test = config.get("entity_ranking.filter_with_test")
         self.filter_splits = self.config.get("entity_ranking.filter_splits")

--- a/kge/job/eval_entity_ranking.py
+++ b/kge/job/eval_entity_ranking.py
@@ -534,9 +534,11 @@ num_ties for each true score.
         true_scores[torch.isnan(true_scores)] = float("-Inf")
 
         # Determine how many scores are greater than / equal to each true answer (in its
-        # corresponding row of scores)
-        rank = torch.sum(scores > true_scores.view(-1, 1), dim=1, dtype=torch.long)
-        num_ties = torch.sum(scores == true_scores.view(-1, 1), dim=1, dtype=torch.long)
+        # corresponding row of scores
+        is_close = torch.isclose(scores, true_scores.view(-1, 1))
+        is_greater = scores > true_scores.view(-1, 1)
+        num_ties = torch.sum(is_close, dim=1, dtype=torch.long)
+        rank = torch.sum(is_greater & ~is_close, dim=1, dtype=torch.long)
         return rank, num_ties
 
     def _get_ranks(self, rank: torch.Tensor, num_ties: torch.Tensor) -> torch.Tensor:

--- a/kge/job/eval_entity_ranking.py
+++ b/kge/job/eval_entity_ranking.py
@@ -536,7 +536,7 @@ num_ties for each true score.
         true_scores[torch.isnan(true_scores)] = float("-Inf")
 
         # Determine how many scores are greater than / equal to each true answer (in its
-        # corresponding row of scores
+        # corresponding row of scores)
         is_close = torch.isclose(scores, true_scores.view(-1, 1), rtol=self.tie_rtol, atol=self.tie_atol)
         is_greater = scores > true_scores.view(-1, 1)
         num_ties = torch.sum(is_close, dim=1, dtype=torch.long)

--- a/kge/job/eval_entity_ranking.py
+++ b/kge/job/eval_entity_ranking.py
@@ -232,9 +232,10 @@ class EntityRankingJob(EvaluationJob):
                     diff_all = torch.cat((diff_a, diff_b))
                     self.config.log(f"Tie-handling: mean difference between scores was: {diff_all.mean()}.")
                     self.config.log(f"Tie-handling: max difference between scores was: {diff_all.max()}.")
-                    raise ValueError("Tie-handling tolerances set too low! The same triples scored twice did not fall "
-                                     "within the configured tolerance. This may be because of a difference between the "
-                                     "SPO and SP_/_PO scoring implementations.")
+                    raise ValueError("Error in tie-handling. The scores assigned to a triple by the SPO and SP_/_PO "
+                                     "scoring implementations were not 'equal' given the configured tolerances. "
+                                     "Verify the model's scoring implementations or consider increasing tie-handling "
+                                     "tolerances.")
 
                 # now compute the rankings (assumes order: None, _filt, _filt_test)
                 for ranking in rankings:


### PR DESCRIPTION
Addresses #221.

I think #222 should still be merged as well, the lower the tolerances can be set, the better.

Will work on tests (expanding on #223) that allow verification of good tolerance values for each model's Scorer.