### PR TITLE
deepcopy _meta dict in reciprocal relations

### DIFF
--- a/kge/model/reciprocal_relations_model.py
+++ b/kge/model/reciprocal_relations_model.py
@@ -26,10 +26,11 @@ class ReciprocalRelationsModel(KgeModel):
         # Using a dataset with twice the number of relations to initialize base model
         alt_dataset = dataset.shallow_copy()
         alt_dataset._num_relations = dataset.num_relations() * 2
-        reciprocal_relation_ids = [
-            rel_id + "_reciprocal" for rel_id in alt_dataset.relation_ids()
-        ]
-        alt_dataset._meta["relation_ids"].extend(reciprocal_relation_ids)
+        alt_dataset._meta = dataset._meta.copy()
+        alt_dataset._meta["relation_ids"] = dataset._meta["relation_ids"].copy()
+        alt_dataset._meta["relation_ids"].extend([
+            rel_id + "_reciprocal" for rel_id in dataset.relation_ids()
+        ])
         base_model = KgeModel.create(
             config=config,
             dataset=alt_dataset,


### PR DESCRIPTION
Quick fix for a small bug. 
Only the reference to the `_meta` dictionary in each dataset was being copied, so the number of relations was doubling each trial while performing a search.