### PR TITLE
Added a checking to see whether any values are NaN in the scoring.

### DIFF
--- a/kge/model/kge_model.py
+++ b/kge/model/kge_model.py
@@ -786,4 +786,8 @@ class KgeModel(KgeBase):
                 all_subjects = self.get_s_embedder().embed_all()
             sp_scores = self._scorer.score_emb(s, p, all_objects, combine="sp_")
             po_scores = self._scorer.score_emb(all_subjects, p, o, combine="_po")
+        if torch.isnan(sp_scores).any().item() or :
+            raise ValueError("Found NaN values when scoring sp_ predictions! ")
+        elif torch.isnan(po_scores).any().item():
+            raise ValueError("Found NaN values when scoring _po predictions! ")
         return torch.cat((sp_scores, po_scores), dim=1)


### PR DESCRIPTION
Regarding issue #220 - by adding a check if there are any NaN values, a `ValueError` will be thrown if a nan-value is found. 

If I am to be self-critical, there is a risk that the speed might be lower, but I still think it is necessary in order to ensure a correct evaluation. 