### PR TITLE
overwrite dataset-config options only if default is currently set

### DIFF
--- a/kge/cli.py
+++ b/kge/cli.py
@@ -251,11 +251,6 @@ def main():
         # disable processing of outdated cached dataset files globally
         Dataset._abort_when_cache_outdated = args.abort_when_cache_outdated
 
-        # log configuration
-        config.log("Configuration:")
-        config.log(yaml.dump(config.options), prefix="  ")
-        config.log("git commit: {}".format(get_git_revision_short_hash()), prefix="  ")
-
         # set random seeds
         seed_from_config(config)
 
@@ -282,6 +277,12 @@ def main():
                     )
             else:
                 job = Job.create(config, dataset)
+
+            # log configuration
+            config.log("Configuration:")
+            config.log(yaml.dump(config.options), prefix="  ")
+            config.log("git commit: {}".format(get_git_revision_short_hash()),
+                       prefix="  ")
             job.run()
     except BaseException:
         tb = traceback.format_exc()

--- a/kge/config.py
+++ b/kge/config.py
@@ -30,6 +30,10 @@ class Config:
 
             with open(filename_in_module(kge, "config-default.yaml"), "r") as file:
                 self.options: Dict[str, Any] = yaml.load(file, Loader=yaml.SafeLoader)
+
+                # Keeps track of the default options set by config-default.yaml.
+                # This allows to check whether a default value was already overwritten
+                # before overwriting this set option again with a new value
                 self.default_options: Dict[str, Any] = deepcopy(self.options)
 
             for m in self.get("import"):
@@ -234,9 +238,12 @@ class Config:
             if overwrite == Config.Overwrite.No:
                 return current_value
             if overwrite == Config.Overwrite.DefaultOnly:
+                warning_message = f"Warning: Avoided overwrite of already set option {key}. Used {current_value} instead of {value}."
                 if key not in self.default_options:
+                    print(warning_message, file=sys.stderr)
                     return current_value
                 elif current_value != self.default_options[key]:
+                    print(warning_message, file=sys.stderr)
                     return current_value
             if overwrite == Config.Overwrite.Error and value != current_value:
                 raise ValueError("key '{}' cannot be overwritten".format(key))

--- a/kge/dataset.py
+++ b/kge/dataset.py
@@ -107,7 +107,10 @@ class Dataset(Configurable):
                 raise ValueError(f"Dataset with name {name} could not be found.")
 
         config.log(f"Loading configuration of dataset {name} from {folder} ...")
-        config.load(os.path.join(folder, "dataset.yaml"))
+        config.load(
+            os.path.join(folder, "dataset.yaml"),
+            overwrite=Config.Overwrite.DefaultOnly
+        )
 
         dataset = Dataset(config, folder)
         if preload_data:


### PR DESCRIPTION
Config options defined in config.yaml or directly in the terminal regarding the dataset are currently overwritten by dataset.yaml; e.g. filenames.
We print to the console the options defined by the user but do not apply them.

This PR fixes this behavior and dataset.yaml only overwrites default options, now.