### PR TITLE
fix logging of training job on resume from checkpoint

### DIFF
--- a/kge/job/job.py
+++ b/kge/job/job.py
@@ -117,7 +117,10 @@ class Job:
         # search jobs don't have a model
         if "model" in checkpoint and checkpoint["model"] is not None:
             model = KgeModel.create_from(
-                checkpoint, new_config=new_config, dataset=dataset
+                checkpoint,
+                new_config=new_config,
+                dataset=dataset,
+                use_tmp_log_folder=False
             )
             config = model.config
             dataset = model.dataset


### PR DESCRIPTION
Currently, logs for the training job are not written to kge.log if we resume from checkpoint.
By default on model.create_from() we use a tmp file for logging.

This small change should fix the issue.