### PR TITLE
restrict the version of sqlalchemy to 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "path",
         # please check correct behaviour when updating ax platform version!!
         "ax-platform>=0.1.19", "botorch>=0.4.0", "gpytorch>=1.4.2",
-        "sqlalchemy",
+        "sqlalchemy<2.0.0",
         "torchviz",
         # LibKGE uses numba typed-dicts which is part of the experimental numba API
         # see http://numba.pydata.org/numba-doc/0.50.1/reference/pysupported.html


### PR DESCRIPTION
The recently released sqlalchemy 2.0 will be installed when its version not restricted in the `setup.py` file. As a result, kge will fail to run due to a breaking change introduced by sqlalchemy 2.0 (the error log is attached below).

This PR will limit the maximum version of sqlalchemy to 1.x to avoid this issue until the `ax-platform` dependency is upgraded to support sqlalchemy 2.0.

```
$ kge
Traceback (most recent call last):
  File "/home/codespace/.python/current/bin/kge", line 33, in <module>
    sys.exit(load_entry_point('libkge', 'console_scripts', 'kge')())
  File "/home/codespace/.python/current/bin/kge", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/local/python/3.10.4/lib/python3.10/importlib/metadata/__init__.py", line 171, in load
    module = import_module(match.group('module'))
  File "/usr/local/python/3.10.4/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/workspaces/kge/kge/cli.py", line 11, in <module>
    from kge.job import Job
  File "/workspaces/kge/kge/job/__init__.py", line 16, in <module>
    from kge.job.search_ax import AxSearchJob
  File "/workspaces/kge/kge/job/search_ax.py", line 8, in <module>
    from ax.service.ax_client import AxClient
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/ax/service/ax_client.py", line 76, in <module>
    from ax.service.utils.with_db_settings_base import DBSettings, WithDBSettingsBase
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/ax/service/utils/with_db_settings_base.py", line 24, in <module>
    from ax.storage.sqa_store.db import init_engine_and_session_factory
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/ax/storage/sqa_store/__init__.py", line 9, in <module>
    from ax.storage.sqa_store import validation
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/ax/storage/sqa_store/validation.py", line 11, in <module>
    from ax.storage.sqa_store.reduced_state import GR_LARGE_MODEL_ATTRS
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/ax/storage/sqa_store/reduced_state.py", line 9, in <module>
    from ax.storage.sqa_store.sqa_classes import SQAGeneratorRun
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/ax/storage/sqa_store/sqa_classes.py", line 231, in <module>
    class SQAGeneratorRun(Base):
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/decl_api.py", line 194, in __init__
    _as_declarative(reg, cls, dict_)
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/decl_base.py", line 246, in _as_declarative
    return _MapperConfig.setup_mapping(registry, cls, dict_, None, {})
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/decl_base.py", line 327, in setup_mapping
    return _ClassScanMapperConfig(
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/decl_base.py", line 558, in __init__
    self._scan_attributes()
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/decl_base.py", line 1000, in _scan_attributes
    collected_annotation = self._collect_annotation(
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/decl_base.py", line 1142, in _collect_annotation
    extracted = _extract_mapped_subtype(
  File "/usr/local/python/3.10.4/lib/python3.10/site-packages/sqlalchemy/orm/util.py", line 2306, in _extract_mapped_subtype
    raise sa_exc.ArgumentError(
sqlalchemy.exc.ArgumentError: Type annotation for "SQAGeneratorRun.arms" can't be correctly interpreted for Annotated Declarative Table form.  ORM annotations should normally make use of the ``Mapped[]`` generic type, or other ORM-compatible generic type, as a container for the actual type, which indicates the intent that the attribute is mapped. Class variables that are not intended to be mapped by the ORM should use ClassVar[].  To allow Annotated Declarative to disregard legacy annotations which don't use Mapped[] to pass, set "__allow_unmapped__ = True" on the class or a superclass this class. (Background on this error at: https://sqlalche.me/e/20/zlpr)

```