### PR TITLE
fix setup.py not including all kge packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name="libkge",
@@ -7,7 +7,7 @@ setup(
     url="https://github.com/uma-pi1/kge",
     author="Universität Mannheim",
     author_email="rgemulla@uni-mannheim.de",
-    packages=["kge"],
+    packages=find_packages(exclude=["tests"]),
     install_requires=[
         "numpy>=1.19.*",
         "torch>=1.7.1",


### PR DESCRIPTION
When kge is installed directly from its Git URL using pip or other python dependency managers, its submodules will be omitted because the packages are not correctly defined in the `setup.py`.

```
$ pip install pip install git+https://github.com/uma-pi1/kge.git
```

Only these files will be present in the installed package:

```
LICENSE
README.md
setup.cfg
setup.py
kge/__init__.py
kge/__main__.py
kge/cli.py
kge/config.py
kge/dataset.py
kge/indexing.py
kge/misc.py
libkge.egg-info/PKG-INFO
libkge.egg-info/SOURCES.txt
libkge.egg-info/dependency_links.txt
libkge.egg-info/entry_points.txt
libkge.egg-info/not-zip-safe
libkge.egg-info/requires.txt
libkge.egg-info/top_level.txt
```

This fix is to include all packages under `kge/` so that a user can correctly install `kge` without having to clone the repository first.