### PR TITLE
fix: set weights_only=False in torch.load for PyTorch 2.6 compatibility

### DIFF
--- a/kge/util/io.py
+++ b/kge/util/io.py
@@ -38,7 +38,7 @@ def load_checkpoint(checkpoint_file: str, device="cpu"):
         raise IOError(
             "Specified checkpoint file {} does not exist.".format(checkpoint_file)
         )
-    checkpoint = torch.load(checkpoint_file, map_location="cpu")
+    checkpoint = torch.load(checkpoint_file, map_location="cpu", weights_only=False)
     if device is not None and "config" in checkpoint:
         checkpoint["config"].set("job.device", device)
     checkpoint["file"] = checkpoint_file


### PR DESCRIPTION
## Problem
PyTorch 2.6 changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Checkpoints saved by libkge contain non-tensor objects (e.g. TorchVersion) that require weights_only=False to load correctly. This breaks checkpoint loading with the error:
```
_pickle.UnpicklingError: Weights only load failed. WeightsUnpickler error: Unsupported global: GLOBAL torch.torch_version.TorchVersion
```

```
/content/drive/MyDrive/kge
Resuming from configuration /content/drive/MyDrive/kge/local/experiments/
Using folder: /content/drive/MyDrive/kge/local/experiments/
Loading configuration of dataset selfloops from /content/drive/MyDrive/kge/data/
Loaded 19734 keys from map entity_ids
Loaded 11149 keys from map relation_ids
Loaded 4022003 train triples
Loaded 502751 valid triples
Loaded 502751 test triples
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/content/drive/MyDrive/kge/kge/__main__.py", line 4, in <module>
    main()
  File "/content/drive/MyDrive/kge/kge/cli.py", line 267, in main
    checkpoint = load_checkpoint(
                 ^^^^^^^^^^^^^^^^
  File "/content/drive/MyDrive/kge/kge/util/io.py", line 41, in load_checkpoint
    checkpoint = torch.load(checkpoint_file, map_location="cpu")
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/serialization.py", line 1548, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. 
	(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
	(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
	WeightsUnpickler error: Unsupported global: GLOBAL torch.torch_version.TorchVersion was not an allowed global by default. Please use `torch.serialization.add_safe_globals([torch.torch_version.TorchVersion])` or the `torch.serialization.safe_globals([torch.torch_version.TorchVersion])` context manager to allowlist this global if you trust this class/function.

Check the documentation of torch.load to learn more about types accepted by default with weights_only https://pytorch.org/docs/stable/generated/torch.load.html.
```
